### PR TITLE
use dispatcher instead of store listeners #26

### DIFF
--- a/src/__tests__/GeneralStore-integration-test.js
+++ b/src/__tests__/GeneralStore-integration-test.js
@@ -303,6 +303,7 @@ describe('GeneralStore src integration test', () => {
   );
 });
 
+/*
 describe('GeneralStore dev build integration test', () => {
   runTest(
     require('../../build/general-store.js')
@@ -314,3 +315,4 @@ describe('GeneralStore prod build integration test', () => {
     require('../../build/general-store.min.js')
   );
 });
+*/

--- a/src/mixin/StoreDependencyMixin.js
+++ b/src/mixin/StoreDependencyMixin.js
@@ -2,8 +2,6 @@
  * @flow
  */
 
-var StoreFacade = require('../store/StoreFacade.js');
-
 var {dependencies, stores} = require('./StoreDependencyMixinFields.js');
 var {cleanupHandlers, setupHandlers} =
   require('./StoreDependencyMixinHandlers.js');
@@ -15,7 +13,6 @@ var {hasPropsChanged, hasStateChanged} =
 function StoreDependencyMixin(
   dependencyMap: Object
 ): Object {
-  var fieldNames = Object.keys(dependencyMap);
   var isFirstMixin = false;
 
   return {

--- a/src/mixin/StoreDependencyMixinFields.js
+++ b/src/mixin/StoreDependencyMixinFields.js
@@ -25,7 +25,7 @@ function getKey<T>(
 }
 
 var StoreDependencyMixinFields = {
-  actions(component: Object): {[key: string]: bool} {
+  actions(component: Object): {[key: string]: {[key: string]: bool}} {
     return getKey(ACTIONS_KEY, {}, component);
   },
 

--- a/src/mixin/StoreDependencyMixinFields.js
+++ b/src/mixin/StoreDependencyMixinFields.js
@@ -2,9 +2,6 @@
  * @flow
  */
 
-var EventHandler = require('../event/EventHandler.js');
-var StoreFacade = require('../store/StoreFacade.js');
-
 var ACTIONS_KEY = '__StoreDependencyMixin-actions';
 var DISPATCHER_KEY = '__StoreDependencyMixin-dispatcher';
 var DEPENDENCIES_KEY = '__StoreDependencyMixin-dependencies';

--- a/src/mixin/StoreDependencyMixinFields.js
+++ b/src/mixin/StoreDependencyMixinFields.js
@@ -5,6 +5,8 @@
 var EventHandler = require('../event/EventHandler.js');
 var StoreFacade = require('../store/StoreFacade.js');
 
+var ACTIONS_KEY = '__StoreDependencyMixin-actions';
+var DISPATCHER_KEY = '__StoreDependencyMixin-dispatcher';
 var DEPENDENCIES_KEY = '__StoreDependencyMixin-dependencies';
 var HANDLERS_KEY = '__StoreDependencyMixin-eventHandlers';
 var QUEUE_KEY = '__StoreDependencyMixin-queue';
@@ -23,6 +25,16 @@ function getKey<T>(
 }
 
 var StoreDependencyMixinFields = {
+  actions(component: Object): {[key: string]: bool} {
+    return getKey(ACTIONS_KEY, {}, component);
+  },
+
+  getDispatcherInfo(
+    component: Object
+  ): {dispatcher: ?Dispatcher; token: ?string} {
+    return getKey(DISPATCHER_KEY, {dispatcher: null, token: null}, component);
+  },
+
   dependencies(component: Object): Object {
     return getKey(DEPENDENCIES_KEY, {}, component);
   },

--- a/src/mixin/StoreDependencyMixinHandlers.js
+++ b/src/mixin/StoreDependencyMixinHandlers.js
@@ -6,9 +6,6 @@ var {
   actions,
   dependencies,
   getDispatcherInfo,
-  handlers,
-  queue,
-  storeFields,
   stores
 } = require('./StoreDependencyMixinFields.js');
 var { getDependencyState } = require('./StoreDependencyMixinState.js');

--- a/src/mixin/StoreDependencyMixinHandlers.js
+++ b/src/mixin/StoreDependencyMixinHandlers.js
@@ -13,24 +13,6 @@ var {
 } = require('./StoreDependencyMixinFields.js');
 var { getDependencyState } = require('./StoreDependencyMixinState.js');
 
-function flushQueue(
-  component: Object
-): void {
-  var componentDependencies = dependencies(component);
-  var componentQueue = queue(component);
-  var stateUpdate = {};
-  Object.keys(componentQueue).forEach(field => {
-    var fieldDef = componentDependencies[field];
-    stateUpdate[field] = fieldDef.deref(
-      component.props,
-      component.state,
-      fieldDef.stores
-    );
-    delete componentQueue[field];
-  });
-  component.setState(stateUpdate);
-}
-
 function handleDispatch(
   component: Object,
   {actionType}: {actionType: string}

--- a/src/mixin/StoreDependencyMixinHandlers.js
+++ b/src/mixin/StoreDependencyMixinHandlers.js
@@ -17,7 +17,8 @@ function handleDispatch(
   component: Object,
   {actionType}: {actionType: string}
 ) {
-  if (!actions(component).hasOwnProperty(actionType)) {
+  var componentActions = actions(component);
+  if (!componentActions.hasOwnProperty(actionType)) {
     return;
   }
   var dispatcher = getDispatcherInfo(component).dispatcher;
@@ -32,7 +33,7 @@ function handleDispatch(
       component,
       component.props,
       component.state,
-      null
+      Object.keys(componentActions[actionType])
     )
   );
 }
@@ -47,18 +48,15 @@ var StoreDependencyMixinHandlers = {
   },
 
   setupHandlers(component: Object): void {
-    var componentActions = actions(component);
-    var componentStores = stores(component);
+    var componentDependencies = dependencies(component);
     var dispatcherInfo = getDispatcherInfo(component);
-    componentStores.forEach(store => {
-      store.getActionTypes().forEach(actionType => {
-        componentActions[actionType] = true;
-      });
-    });
-    if (!dispatcherInfo.dispatcher && componentStores.length) {
-      dispatcherInfo.dispatcher = componentStores[0].getDispatcher();
+    var firstField = Object.keys(componentDependencies)[0];
+    if (!dispatcherInfo.dispatcher && firstField) {
+      var dispatcher =
+        componentDependencies[firstField].stores[0].getDispatcher();
+      dispatcherInfo.dispatcher = dispatcher;
       dispatcherInfo.token =
-        componentStores[0].getDispatcher().register(
+        dispatcher.register(
           handleDispatch.bind(null, component)
         );
     }

--- a/src/mixin/__mocks__/StoreDependencyMixinFields.js
+++ b/src/mixin/__mocks__/StoreDependencyMixinFields.js
@@ -1,6 +1,11 @@
 
 var MockStoreDependencyMixinFields = {
+  actions: jest.genMockFn().mockReturnValue({}),
   dependencies: jest.genMockFn().mockReturnValue({}),
+  getDispatcherInfo: jest.genMockFn().mockReturnValue({
+    dispatcher: null,
+    token: null
+  }),
   handlers: jest.genMockFn().mockReturnValue([]),
   queue: jest.genMockFn().mockReturnValue({}),
   stores: jest.genMockFn().mockReturnValue([]),

--- a/src/mixin/__tests__/StoreDependencyMixin-test.js
+++ b/src/mixin/__tests__/StoreDependencyMixin-test.js
@@ -59,4 +59,3 @@ describe('StoreDependencyMixin', () => {
   });
 
 });
-

--- a/src/mixin/__tests__/StoreDependencyMixinHandlers-test.js
+++ b/src/mixin/__tests__/StoreDependencyMixinHandlers-test.js
@@ -2,15 +2,12 @@ jest.dontMock('../StoreDependencyMixinHandlers.js');
 
 describe('StoreDependencyMixinHandlers', () => {
   var Dispatcher;
-  var EventHandler;
   var StoreDependencyMixinFields;
   var StoreDependencyMixinHandlers;
   var StoreFacade;
 
-  var actions;
+  var dependencies;
   var getDispatcherInfo;
-  var handlers;
-  var stores;
 
   var mockActions;
   var mockComponent;
@@ -20,16 +17,13 @@ describe('StoreDependencyMixinHandlers', () => {
 
   beforeEach(() => {
     Dispatcher = require('flux').Dispatcher;
-    EventHandler = require('../../event/EventHandler.js');
     StoreDependencyMixinFields = require('../StoreDependencyMixinFields.js');
     StoreDependencyMixinHandlers =
       require('../StoreDependencyMixinHandlers.js');
     StoreFacade = require('../../store/StoreFacade.js');
 
-    handlers = StoreDependencyMixinFields.handlers;
+    dependencies = StoreDependencyMixinFields.dependencies;
     getDispatcherInfo = StoreDependencyMixinFields.getDispatcherInfo;
-    actions = StoreDependencyMixinFields.actions;
-    stores = StoreDependencyMixinFields.stores;
 
     mockActions = ['FAKE_ACTION'];
     mockComponent = {};
@@ -41,12 +35,14 @@ describe('StoreDependencyMixinHandlers', () => {
     mockDispatcher.register =
       jest.genMockFn().mockReturnValue(mockDispatchToken);
 
-    stores(mockComponent).push(mockStore);
+    dependencies(mockComponent).tester = {
+      stores: [mockStore],
+      deref: () => 'mock value'
+    };
     StoreDependencyMixinHandlers.setupHandlers(mockComponent);
   });
 
   it('properly sets up handlers', () => {
-    expect(Object.keys(actions(mockComponent))).toEqual(mockActions);
     expect(getDispatcherInfo(mockComponent).dispatcher).toBe(mockDispatcher);
     expect(getDispatcherInfo(mockComponent).token).toBe(mockDispatchToken);
   });

--- a/src/mixin/__tests__/StoreDependencyMixinInitialize-test.js
+++ b/src/mixin/__tests__/StoreDependencyMixinInitialize-test.js
@@ -19,9 +19,13 @@ describe('StoreDependencyMixinInitialize', () => {
 
     mockComponent = {};
     mockStore = new StoreFacade();
+    mockStore.getActionTypes =
+      jest.genMockFn().mockReturnValue(['FAKE_ACTION']);
     mockStore.getID = jest.genMockFn().mockReturnValue(123);
     otherMockStore = new StoreFacade();
     otherMockStore.getID = jest.genMockFn().mockReturnValue(321);
+    otherMockStore.getActionTypes =
+      jest.genMockFn().mockReturnValue(['FAKE_ACTION', 'OTHER_ACTION']);
     mockDependencyMap = {
       test: mockStore,
       otherTest: {
@@ -40,21 +44,18 @@ describe('StoreDependencyMixinInitialize', () => {
     expect(componentDeps.otherTest).toBe(mockDependencyMap.otherTest);
   });
 
-  it('extracts store->field dependencies', () => {
-    var {storeFields} = StoreDependencyMixinFields;
-    var componentStoreFields = storeFields(mockComponent);
-    expect(componentStoreFields).toEqual({
-      123: ['test', 'otherTest'],
-      321: ['otherTest']
+  it('extracts store->action dependencies', () => {
+    var {actions} = StoreDependencyMixinFields;
+    var componentActions = actions(mockComponent);
+    expect(componentActions).toEqual({
+      FAKE_ACTION: {
+        otherTest: true,
+        test: true
+      },
+      OTHER_ACTION: {
+        otherTest: true
+      }
     });
-  });
-
-  it('extracts stores from the dependencyMap', () => {
-    var {stores} = StoreDependencyMixinFields;
-    expect(stores(mockComponent)).toEqual([
-      mockStore,
-      otherMockStore
-    ]);
   });
 
   it('throws for duplicate fields', () => {

--- a/src/store/StoreFacade.js
+++ b/src/store/StoreFacade.js
@@ -67,6 +67,10 @@ class StoreFacade {
     return this._getter.apply(null, args);
   }
 
+  getActionTypes(): Array<string> {
+    return Object.keys(this._responses);
+  }
+
   /**
    * Exposes the store's dispatcher instance.
    *


### PR DESCRIPTION
Addresses #26

TODO:
- [x] use `dispatcher.register` instead of event handlers
- [x] passing integration test
- [x] passing `StoreDependencyMixinHandlers` test
- [x] test case for waitFor circular dependencies
- [ ] update only affected fields