### PR TITLE
Don't rely on window.Immutable (fixes #34)

### DIFF
--- a/bin/build-dev
+++ b/bin/build-dev
@@ -2,6 +2,7 @@
 NODE_ENV=development \
 browserify \
   --standalone GeneralStore \
+  --external immutable \
   -p browserify-derequire \
   -t babelify \
   -t envify \

--- a/bin/build-prod
+++ b/bin/build-prod
@@ -2,6 +2,7 @@
 NODE_ENV=production \
 browserify \
   --standalone GeneralStore \
+  --external immutable \
   -p bundle-collapser/plugin \
   -p browserify-derequire \
   -t babelify \

--- a/lib/immutable.js
+++ b/lib/immutable.js
@@ -1,0 +1,5 @@
+
+declare module "immutable.js" {
+  declare function is(a: any, b: any): bool;
+}
+

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^0.19.0",
     "flow-bin": "^0.2.0",
     "flux": "^2.0.1",
+    "immutable": "^3.7.4",
     "jest-cli": "^0.4.0",
     "recast": "^0.9.17",
     "through2": "^0.6.3",

--- a/src/mixin/StoreDependencyMixinTransitions.js
+++ b/src/mixin/StoreDependencyMixinTransitions.js
@@ -5,7 +5,8 @@
 try {
   var compare = require('immutable').is;
 } catch (e) {
-  if (typeof window === 'object' && window.Immutable && typeof window.Immutable.is === 'function') {
+  if (typeof window === 'object' && window.Immutable &&
+      typeof window.Immutable.is === 'function') {
     var compare = window.Immutable.is;
   } else {
     var compare = (a, b) => a === b;

--- a/src/mixin/StoreDependencyMixinTransitions.js
+++ b/src/mixin/StoreDependencyMixinTransitions.js
@@ -2,9 +2,15 @@
  * @flow
  */
 
-var compare = (window.Immutable && typeof window.Immutable.is === 'function') ?
-  window.Immutable.is :
-  (a, b) => a === b;
+try {
+  var compare = require('immutable').is;
+} catch (e) {
+  if (typeof window === 'object' && window.Immutable && typeof window.Immutable.is === 'function') {
+    var compare = window.Immutable.is;
+  } else {
+    var compare = (a, b) => a === b;
+  }
+}
 
 function compareKey(key, objA, objB) {
   return compare(objA[key], objB[key]);


### PR DESCRIPTION
- Checks that `window` exists, before trying to use it.
- Before using `window.Immutable` try `require("immutable")`.
- Declare 'immutable' as an external so Immutable will not be bundled into dist/ and browserify will check to see if Immutable is defined outside the static bundle.