### PR TITLE
throw if more than one mixin is detected + initialize in getInitialState

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/__tests__/GeneralStore-integration-test.js
+++ b/src/__tests__/GeneralStore-integration-test.js
@@ -170,7 +170,7 @@ function runTest(GeneralStore) {
       users: {},
     });
     addUser(mockUser);
-    expect(mockComponent.setState.mock.calls.length).toBe(2);
+    expect(mockComponent.setState.mock.calls.length).toBe(1);
     expect(mockComponent.state).toEqual({
       users: {
         '123': mockUser,
@@ -194,7 +194,7 @@ function runTest(GeneralStore) {
       userIds: [],
     });
     addUser(mockUser);
-    expect(mockComponent.setState.mock.calls.length).toBe(2);
+    expect(mockComponent.setState.mock.calls.length).toBe(1);
     expect(mockComponent.state).toEqual({
       users: {
         [mockUser.id]: mockUser,
@@ -225,7 +225,7 @@ function runTest(GeneralStore) {
       },
       userCount: 1,
     });
-    expect(mockComponent.setState.mock.calls.length).toBe(2);
+    expect(mockComponent.setState.mock.calls.length).toBe(1);
   });
 }
 

--- a/src/dependencies/StoreDependencyMixin.js
+++ b/src/dependencies/StoreDependencyMixin.js
@@ -49,10 +49,15 @@ export default function StoreDependencyMixin(
 
   const mixin: ReactMixin = {
     getInitialState(): Object {
-      return {};
+      return calculateInitial(dependencies, this.props, this.state);
     },
 
     componentWillMount(): void {
+      invariant(
+        this.__dispatchToken === undefined,
+        'Only one `StoreDependencyMixin` may be registered on `%s`',
+        this.constructor.displayName
+      );
       if (dispatcher) {
         this.__dispatchToken = dispatcher.register(
           handleDispatch.bind(
@@ -67,9 +72,6 @@ export default function StoreDependencyMixin(
           )
         );
       }
-      this.setState(
-        calculateInitial(dependencies, this.props, this.state)
-      );
     },
 
     componentWillReceiveProps(nextProps): void {


### PR DESCRIPTION
Adds an invariant that checks if another `StoreDependencyMixin` has already been initialized on the component. Currently that wouldn't work but it wouldn't work silently and end up throwing in `componentWillUnmount`.

Also initializes the mixin in `getInitialState` to maintain backwards compatibility and get state key conflict errors.