### PR TITLE
Fix undefined state on prop change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/dependencies/DependencyMap.js
+++ b/src/dependencies/DependencyMap.js
@@ -135,12 +135,13 @@ export function calculateForDispatch(
 
 export function calculateForPropsChange(
   dependencies: DependencyMap,
-  props: Object
+  props: Object,
+  state: ?Object
 ): Object {
   return oFilterMap(
     dependencies,
     (dep) => dep.deref && dep.deref.length > 0,
-    (dep) => calculate(dep, props)
+    (dep) => calculate(dep, props, state)
   );
 }
 

--- a/src/dependencies/DependencyMap.js
+++ b/src/dependencies/DependencyMap.js
@@ -141,7 +141,12 @@ export function calculateForPropsChange(
   return oFilterMap(
     dependencies,
     (dep) => dep.deref && dep.deref.length > 0,
-    (dep) => calculate(dep, props, state)
+    (dep) => {
+      if (dep.deref.length === 1) {
+        return calculate(dep, props);
+      }
+      return calculate(dep, props, state);
+    }
   );
 }
 

--- a/src/dependencies/DependencyMap.js
+++ b/src/dependencies/DependencyMap.js
@@ -141,12 +141,7 @@ export function calculateForPropsChange(
   return oFilterMap(
     dependencies,
     (dep) => dep.deref && dep.deref.length > 0,
-    (dep) => {
-      if (dep.deref.length === 1) {
-        return calculate(dep, props);
-      }
-      return calculate(dep, props, state);
-    }
+    (dep) => calculate(dep, props, state)
   );
 }
 

--- a/src/dependencies/StoreDependencyMixin.js
+++ b/src/dependencies/StoreDependencyMixin.js
@@ -76,7 +76,7 @@ export default function StoreDependencyMixin(
 
     componentWillReceiveProps(nextProps): void {
       this.setState(
-        calculateForPropsChange(dependencies, nextProps)
+        calculateForPropsChange(dependencies, nextProps, this.state)
       );
     },
 

--- a/src/dependencies/__tests__/DependencyMap-test.js
+++ b/src/dependencies/__tests__/DependencyMap-test.js
@@ -58,6 +58,10 @@ describe('DependencyMap', () => {
         stores: [CountStore],
         deref: (props, state) => CountStore.get() * 100,
       },
+      timesAHundredMinusState: {
+        stores: [CountStore],
+        deref: (props, state) => CountStore.get() * 100 - state.testState,
+      },
     };
   });
 
@@ -190,6 +194,7 @@ describe('DependencyMap', () => {
         count: initialState,
         negativeCount: -initialState,
         timesAHundred: initialState * 100,
+        timesAHundredMinusState: initialState * 100 - mockState.testState,
       });
     });
   });
@@ -226,6 +231,7 @@ describe('DependencyMap', () => {
       expect(result).toEqual({
         absCount: initialState,
         timesAHundred: initialState * 100,
+        timesAHundredMinusState: initialState * 100 - mockState.testState,
       });
     });
   });
@@ -238,7 +244,8 @@ describe('DependencyMap', () => {
         mockState
       );
       expect(result).toEqual({
-        timesAHundred: initialState * 100
+        timesAHundred: initialState * 100,
+        timesAHundredMinusState: initialState * 100 - mockState.testState,
       });
     });
   });
@@ -251,6 +258,7 @@ describe('DependencyMap', () => {
         negativeCount: true,
         absCount: true,
         timesAHundred: true,
+        timesAHundredMinusState: true,
       });
     });
 

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -56,7 +56,7 @@ export default function connect(
 
       componentWillReceiveProps(nextProps: Object): void {
         this.setState(
-          calculateForPropsChange(dependencies, nextProps)
+          calculateForPropsChange(dependencies, nextProps, this.state)
         );
       }
 


### PR DESCRIPTION
Because `timesAHundredMinusState` never actually used `state`, it was unnoticed that `state` would be `undefined` when the `deref` was called from `componentWillReceiveProps`. This change should pass the current `state` through at the time of `componentWillReceiveProps` and update the tests to reflect that case.

It looks like the Change log wasnt updated for v1, so I also didn't add anything for this fix. If there is anything else that I missed, let me know.

/cc @colbyr 