### PR TITLE
Redefine getinitialstate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+* `defineGetInitialState` allows redefinition for your testing convenience
+
 ## 1.3.0
 * `connect` transfers static properties/methods from the `BaseComponent` to the `ConnectedComponent`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.1
+## 1.4.0
 * `defineGetInitialState` allows redefinition for your testing convenience
 
 ## 1.3.0

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/store/StoreFactory.js
+++ b/src/store/StoreFactory.js
@@ -82,10 +82,6 @@ export default class StoreFactory {
       typeof getInitialState === 'function',
       'StoreFactory.defineGetInitialState: getInitialState must be a function.'
     );
-    invariant(
-      this._definition.getInitialState === defaultGetInitialState,
-      'StoreFactory.defineGetInitialState: getInitialState is already defined.'
-    );
     return new StoreFactory({
       ...this._definition,
       getInitialState,

--- a/src/store/__tests__/StoreFactory-test.js
+++ b/src/store/__tests__/StoreFactory-test.js
@@ -57,13 +57,13 @@ describe('StoreFactory', () => {
     expect(() => storeFactory.defineGetInitialState({})).toThrow();
   });
 
-  it('throws when initialState is already set', () => {
+  it('does not throw when initialState is already set', () => {
     const emptyFn = EMPTY_FUNC;
     const factoryWithGetInitialState = storeFactory
       .defineGetInitialState(emptyFn);
     expect(
       () => factoryWithGetInitialState.defineGetInitialState(emptyFn)
-    ).toThrow();
+    ).not.toThrow();
   });
 
   it('sets responses', () => {


### PR DESCRIPTION
Allows redefinition of `definiteGetInitialState` which is seriously useful in unit tests.

Instead of having to dispatch a bunch of actions to get to the starting state you want, you can update the factory to jump right to it.