### PR TITLE
InspectStore and Store names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 2.0.0
+* adds `StoreFactory#defineName`
+* adds `Store#toString`
 * adds `GeneralStore.InspectStore` for examining internal state of a store
 * removes `Store#getActionTypes`
 * removes `Store#getDispatcher`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.0
+* adds `GeneralStore.InspectStore` for examining internal state of a store
+* removes `Store#getActionTypes`
+* removes `Store#getDispatcher`
+* removes `Store#getDispatchToken`
+* removes `Store#getFactory`
+* removes `Store#getID`
+
 ## 1.4.0
 * `defineGetInitialState` allows redefinition for your testing convenience
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ describe('UserStore', () => {
 });
 ```
 
+To further assist with testing, the [`InspectStore`](https://github.com/HubSpot/general-store/blob/master/src/store/InspectStore.js) module allows you to read the internal fields of a store instance (e.g. `InspectStore.getState(store)`).
+
 ## Using the Store API
 
 A registered Store provides methods for "getting" its value and subscribing to changes to that value.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ function defineUserStore() {
   };
 
   return GeneralStore.define()
+    .defineName('UserStore')
     // the store's getter should return the public subset of its data
     .defineGet(function() {
       return users;
@@ -99,6 +100,7 @@ testing easier and allows you to extend store behavior.
 
 ```javascript
 var UserStoreFactory = GeneralStore.defineFactory()
+  .defineName('UserStore')
   .defineGetInitialState(function() {
     return {};
   })

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
       "immutable-is",
       "invariant",
       "<rootDir>/src/dispatcher/DispatcherInterface.js",
+      "<rootDir>/src/store/InspectStore.js",
       "<rootDir>/src/uniqueid",
       "<rootDir>/src/utils/ObjectUtils.js"
     ]

--- a/src/GeneralStore.js
+++ b/src/GeneralStore.js
@@ -1,6 +1,7 @@
 /* @flow */
 import connect from './dependencies/connect';
 import * as DispatcherInstance from './dispatcher/DispatcherInstance';
+import * as InspectStore from './store/InspectStore';
 import StoreDependencyMixin from './dependencies/StoreDependencyMixin';
 import StoreSingleton from './store/StoreSingleton';
 import StoreFactory from './store/StoreFactory';
@@ -18,5 +19,6 @@ module.exports = {
   define: defineSingleton,
   defineFactory,
   DispatcherInstance,
+  InspectStore,
   StoreDependencyMixin,
 };

--- a/src/dependencies/DependencyMap.js
+++ b/src/dependencies/DependencyMap.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { getActionTypes, getDispatchToken } from '../store/InspectStore';
 import invariant from 'invariant';
 import {
   oFilterMap,
@@ -174,12 +175,12 @@ export function makeDependencyIndex(
   return oReduce(dependencies, (index, dep, field) => {
     const stores = dep instanceof Store ? [dep] : dep.stores;
     stores.forEach((store) => {
-      store.getActionTypes().forEach((actionType) => {
+      getActionTypes(store).forEach((actionType) => {
         let entry = index[actionType];
         if (!entry) {
           entry = index[actionType] = makeIndexEntry();
         }
-        const token = store.getDispatchToken();
+        const token = getDispatchToken(store);
         entry.dispatchTokens[token] = true;
         entry.fields[field] = true;
       });

--- a/src/dependencies/__tests__/DependencyMap-test.js
+++ b/src/dependencies/__tests__/DependencyMap-test.js
@@ -15,6 +15,7 @@ import {
   makeDependencyIndex,
 } from '../DependencyMap';
 import { Dispatcher } from 'flux';
+import { getDispatchToken } from '../../store/InspectStore';
 import Store from '../../store/Store';
 import StoreFactory from '../../store/StoreFactory';
 
@@ -265,7 +266,7 @@ describe('DependencyMap', () => {
     it('properly calculates dispatchTokens affected by actions', () => {
       const index = makeDependencyIndex(dependencies);
       expect(index[INCREMENT].dispatchTokens).toEqual({
-        [CountStore.getDispatchToken()]: true,
+        [getDispatchToken(CountStore)]: true,
       });
     });
   });

--- a/src/dependencies/__tests__/StoreDependencyMixin-test.js
+++ b/src/dependencies/__tests__/StoreDependencyMixin-test.js
@@ -1,6 +1,7 @@
 jest.disableAutomock();
 import { Dispatcher } from 'flux';
 import { shallow } from 'enzyme';
+import { getDispatchToken } from '../../store/InspectStore';
 import React, { PropTypes } from 'react';
 import StoreDependencyMixin from '../StoreDependencyMixin';
 import StoreFactory from '../../store/StoreFactory';
@@ -152,8 +153,8 @@ describe('StoreDependencyMixin', () => {
       shallow(<MockComponent />);
       dispatcher.dispatch({actionType: SHARED});
       expect(dispatcher.waitFor.mock.calls[0][0]).toEqual([
-        FirstStore.getDispatchToken(),
-        SecondStore.getDispatchToken(),
+        getDispatchToken(FirstStore),
+        getDispatchToken(SecondStore),
       ]);
     });
 

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -1,6 +1,7 @@
 jest.disableAutomock();
 import { Dispatcher } from 'flux';
 import { shallow } from 'enzyme';
+import { getDispatchToken } from '../../store/InspectStore';
 import React, { PropTypes } from 'react';
 import connect from '../connect';
 import StoreFactory from '../../store/StoreFactory';
@@ -126,8 +127,8 @@ describe('connect', () => {
       shallow(<MockComponent />);
       dispatcher.dispatch({actionType: SHARED});
       expect(dispatcher.waitFor.mock.calls[0][0]).toEqual([
-        FirstStore.getDispatchToken(),
-        SecondStore.getDispatchToken(),
+        getDispatchToken(FirstStore),
+        getDispatchToken(SecondStore),
       ]);
     });
 

--- a/src/store/InspectStore.js
+++ b/src/store/InspectStore.js
@@ -3,16 +3,16 @@ import type { Dispatcher } from 'flux';
 import type Store, { StoreResponses } from './Store';
 import type StoreFactory from './StoreFactory';
 
+export function getActionTypes(store: Store): Array<string> {
+  return Object.keys(store._responses) || [];
+}
+
 export function getDispatcher(store: Store): Dispatcher {
   return store._dispatcher;
 }
 
 export function getDispatchToken(store: Store): string {
   return store._dispatchToken;
-}
-
-export function getActionTypes(store: Store): Array<string> {
-  return Object.keys(store._responses) || [];
 }
 
 export function getGetter(store: Store): (...args: Array<any>) => any {
@@ -25,6 +25,10 @@ export function getId(store: Store): string {
 
 export function getFactory(store: Store): StoreFactory {
   return store._factory;
+}
+
+export function getName(store: Store): string {
+  return store._name;
 }
 
 export function getResponses(store: Store): StoreResponses {

--- a/src/store/InspectStore.js
+++ b/src/store/InspectStore.js
@@ -1,0 +1,36 @@
+/* @flow */
+import type { Dispatcher } from 'flux';
+import type Store, { StoreResponses } from './Store';
+import type StoreFactory from './StoreFactory';
+
+export function getDispatcher(store: Store): Dispatcher {
+  return store._dispatcher;
+}
+
+export function getDispatchToken(store: Store): string {
+  return store._dispatchToken;
+}
+
+export function getActionTypes(store: Store): Array<string> {
+  return Object.keys(store._responses) || [];
+}
+
+export function getGetter(store: Store): (...args: Array<any>) => any {
+  return store._getter;
+}
+
+export function getId(store: Store): string {
+  return store._uid;
+}
+
+export function getFactory(store: Store): StoreFactory {
+  return store._factory;
+}
+
+export function getResponses(store: Store): StoreResponses {
+  return store._responses;
+}
+
+export function getState(store: Store) {
+  return store._state;
+}

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -16,7 +16,9 @@ function getNull() {
   return null;
 }
 
-type StoreResponses = {
+export type StoreGetter = (...args: Array<any>) => any;
+
+export type StoreResponses = {
   [key:string]: (
     state: any,
     data: any,
@@ -38,7 +40,7 @@ export default class Store {
   _dispatcher: Dispatcher;
   _dispatchToken: string;
   _factory: StoreFactory;
-  _getter: (...args: Array<any>) => any;
+  _getter: StoreGetter;
   _event: Event;
   _responses: StoreResponses;
   _state: any;
@@ -91,36 +93,6 @@ export default class Store {
     return this._getter(this._state, ...args);
   }
 
-  getActionTypes() {
-    return Object.keys(this._responses) || [];
-  }
-
-  /**
-   * Exposes the store's dispatcher instance.
-   *
-   * @return Dispatcher
-   */
-  getDispatcher(): Dispatcher {
-    return this._dispatcher;
-  }
-
-  /**
-   * Exposes the token assigned to the store by the dispatcher
-   *
-   * @return number
-   */
-  getDispatchToken(): string {
-    return this._dispatchToken;
-  }
-
-  getFactory(): StoreFactory {
-    return this._factory;
-  }
-
-  getID(): string {
-    return this._uid;
-  }
-
   /**
    * @protected
    * Responds to incoming messages from the Dispatcher
@@ -157,7 +129,7 @@ export default class Store {
    * Dispatch callback is unregistered. Subscriptions are removed.
    */
   remove(): void {
-    this._dispatcher.unregister(this.getDispatchToken());
+    this._dispatcher.unregister(this._dispatchToken);
     this._event.remove();
     this._getter = getNull;
     this._responses = {};

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -32,7 +32,8 @@ type StoreOptions = {
   factory: StoreFactory;
   getter: (...args: Array<any>) => any;
   initialState: any;
-  responses: {}
+  name: ?string;
+  responses: {};
 };
 
 export default class Store {
@@ -42,6 +43,7 @@ export default class Store {
   _factory: StoreFactory;
   _getter: StoreGetter;
   _event: Event;
+  _name: string;
   _responses: StoreResponses;
   _state: any;
   _uid: string;
@@ -51,11 +53,13 @@ export default class Store {
     factory,
     getter,
     initialState,
+    name,
     responses,
   }: StoreOptions) {
     this._dispatcher = dispatcher;
     this._factory = factory;
     this._getter = getter;
+    this._name = name || 'Store';
     this._state = initialState;
     this._responses = responses;
     this._event = new Event();
@@ -135,6 +139,10 @@ export default class Store {
     this._responses = {};
   }
 
+  toString(): string {
+    return `${this._name}<${this._state}>`;
+  }
+
   /**
    * Runs all of the store's subscription callbacks
    *
@@ -153,5 +161,4 @@ export default class Store {
     this._event.runHandlers();
     return this;
   }
-
 }

--- a/src/store/StoreFactory.js
+++ b/src/store/StoreFactory.js
@@ -43,6 +43,7 @@ type Responses = {
 type StoreFactoryDefinition = {
   getter: Getter;
   getInitialState: () => any;
+  name: ?string;
   responses: Responses;
 };
 
@@ -58,10 +59,11 @@ export default class StoreFactory {
 
   _definition: StoreFactoryDefinition;
 
-  constructor({getter, getInitialState, responses}:Object) {
+  constructor({getter, getInitialState, name, responses}:Object) {
     this._definition = {
       getter: getter || defaultGetter,
       getInitialState: getInitialState || defaultGetInitialState,
+      name,
       responses: responses || {},
     };
   }
@@ -85,6 +87,13 @@ export default class StoreFactory {
     return new StoreFactory({
       ...this._definition,
       getInitialState,
+    });
+  }
+
+  defineName(name: string) {
+    return new StoreFactory({
+      ...this._definition,
+      name,
     });
   }
 
@@ -145,12 +154,13 @@ export default class StoreFactory {
       ' https://github.com/HubSpot/general-store#dispatcher-interface',
       dispatcher
     );
-    const {getter, getInitialState, responses} = this._definition;
+    const {getter, getInitialState, name, responses} = this._definition;
     return new Store({
       dispatcher,
       factory: this,
       getter,
       initialState: getInitialState(),
+      name,
       responses,
     });
   }

--- a/src/store/StoreFactory.js
+++ b/src/store/StoreFactory.js
@@ -91,9 +91,10 @@ export default class StoreFactory {
   }
 
   defineName(name: string) {
+    const currentName = this._definition.name;
     return new StoreFactory({
       ...this._definition,
-      name,
+      name: currentName ? `${name}(${currentName})` : name,
     });
   }
 

--- a/src/store/__tests__/InspectStore-test.js
+++ b/src/store/__tests__/InspectStore-test.js
@@ -32,6 +32,7 @@ describe('InspectStore', () => {
     secondHandler = jest.genMockFn();
 
     factory = new StoreFactory({})
+      .defineName('TestStore')
       .defineGet(getter)
       .defineGetInitialState(() => {
         return {testing: 'yes'};
@@ -63,6 +64,10 @@ describe('InspectStore', () => {
 
   it('getFactory', () => {
     expect(InspectStore.getFactory(store)).toBe(factory);
+  });
+
+  it('getName', () => {
+    expect(InspectStore.getName(store)).toBe('TestStore');
   });
 
   it('getResponses', () => {

--- a/src/store/__tests__/InspectStore-test.js
+++ b/src/store/__tests__/InspectStore-test.js
@@ -1,0 +1,78 @@
+jest.unmock('../InspectStore');
+jest.unmock('../Store');
+jest.unmock('../StoreFactory');
+
+describe('InspectStore', () => {
+  let InspectStore;
+  let StoreFactory;
+
+  const FIRST_ACTION = 'FIRST_ACTION';
+  const SECOND_ACTION = 'SECOND_ACTION';
+
+  let dispatcher;
+  let dispatchToken;
+  let factory;
+  let firstHandler;
+  let getter;
+  let secondHandler;
+  let store;
+
+  beforeEach(() => {
+    InspectStore = require('../InspectStore');
+    StoreFactory = require('../StoreFactory').default;
+
+    dispatchToken = 'testing_1';
+    dispatcher = {
+      isDispatching: jest.genMockFn().mockReturnValue(true),
+      register: jest.genMockFn().mockReturnValue(dispatchToken),
+      unregister: jest.genMockFn(),
+    };
+    getter = (state) => state;
+    firstHandler = jest.genMockFn();
+    secondHandler = jest.genMockFn();
+
+    factory = new StoreFactory({})
+      .defineGet(getter)
+      .defineGetInitialState(() => {
+        return {testing: 'yes'};
+      })
+      .defineResponseTo(FIRST_ACTION, firstHandler)
+      .defineResponseTo(SECOND_ACTION, secondHandler);
+    store = factory.register(dispatcher);
+  });
+
+  it('getDispatcher', () => {
+    expect(InspectStore.getDispatcher(store)).toBe(dispatcher);
+  });
+
+  it('getDispatchToken', () => {
+    expect(InspectStore.getDispatchToken(store)).toBe(dispatchToken);
+  });
+
+  it('getActionTypes', () => {
+    expect(InspectStore.getDispatchToken(store)).toBe(dispatchToken);
+  });
+
+  it('getGetter', () => {
+    expect(InspectStore.getGetter(store)).toBe(getter);
+  });
+
+  it('getId', () => {
+    expect(InspectStore.getId(store)).toBe(store._uid);
+  });
+
+  it('getFactory', () => {
+    expect(InspectStore.getFactory(store)).toBe(factory);
+  });
+
+  it('getResponses', () => {
+    expect(InspectStore.getResponses(store)).toEqual({
+      FIRST_ACTION: firstHandler,
+      SECOND_ACTION: secondHandler,
+    });
+  });
+
+  it('getState', () => {
+    expect(InspectStore.getState(store)).toEqual({testing: 'yes'});
+  });
+});

--- a/src/store/__tests__/Store-test.js
+++ b/src/store/__tests__/Store-test.js
@@ -77,10 +77,6 @@ describe('Store', () => {
     expect(mockGet.mock.calls[0][2]).toBe(mockArg2);
   });
 
-  it('returns the dispatch token from getDispatchToken', () => {
-    expect(storeFacade.getDispatchToken()).toBe(mockDispatchToken);
-  });
-
   it('runs listeners after a definedResponse', () => {
     const mockListener = jest.genMockFn();
     const mockEvent = require('../../event/Event.js').default.mock.instances[0];

--- a/src/store/__tests__/Store-test.js
+++ b/src/store/__tests__/Store-test.js
@@ -9,6 +9,7 @@ describe('Store', () => {
   let mockDispatchToken;
   let mockGet;
   let mockInitialState;
+  let mockName;
   let mockResponse;
   let mockResponses;
 
@@ -23,6 +24,7 @@ describe('Store', () => {
       unregister: jest.genMockFn(),
     };
     mockGet = jest.genMockFn().mockImpl((state) => state.count);
+    mockName = 'TestStore';
     mockResponse = jest.genMockFn().mockImpl((state) => {
       return {count: state.count + 1};
     });
@@ -32,6 +34,7 @@ describe('Store', () => {
     storeFacade = new Store({
       getter: mockGet,
       initialState: mockInitialState,
+      name: mockName,
       responses: mockResponses,
       dispatcher: mockDispatcher,
     });
@@ -39,6 +42,14 @@ describe('Store', () => {
 
   it('registers with the dispatcher', () => {
     expect(mockDispatcher.register.mock.calls.length).toBe(1);
+  });
+
+  it('sets the name', () => {
+    expect(storeFacade._name).toBe(mockName);
+  });
+
+  it('toStrings', () => {
+    expect(storeFacade.toString()).toBe('TestStore<[object Object]>');
   });
 
   it('runs responses when the associated action is dispatched', () => {

--- a/src/store/__tests__/StoreFactory-test.js
+++ b/src/store/__tests__/StoreFactory-test.js
@@ -38,6 +38,13 @@ describe('StoreFactory', () => {
     expect(newDef.name).toBe(mockName);
   });
 
+  it('compounds the name', () => {
+    const first = 'first';
+    const second = 'second';
+    const newDef = storeFactory.defineName(first).defineName(second).getDefinition();
+    expect(newDef.name).toBe('second(first)');
+  });
+
   it('sets getter', () => {
     const mockGetter = EMPTY_FUNC;
     const newDef = storeFactory.defineGet(mockGetter).getDefinition();

--- a/src/store/__tests__/StoreFactory-test.js
+++ b/src/store/__tests__/StoreFactory-test.js
@@ -32,6 +32,12 @@ describe('StoreFactory', () => {
     ).not.toBe(storeFactory);
   });
 
+  it('sets the name', () => {
+    const mockName = 'testing';
+    const newDef = storeFactory.defineName(mockName).getDefinition();
+    expect(newDef.name).toBe(mockName);
+  });
+
   it('sets getter', () => {
     const mockGetter = EMPTY_FUNC;
     const newDef = storeFactory.defineGet(mockGetter).getDefinition();


### PR DESCRIPTION
Adds an `InspectStore` module for accessing internal store state like state and raw action responses in tests.

Adds a `defineName` to assist in identifying store instances.