### PR TITLE
connectCallback

### DIFF
--- a/src/dependencies/StoreDependencyMixin.js
+++ b/src/dependencies/StoreDependencyMixin.js
@@ -12,7 +12,7 @@ import {
 } from '../dependencies/DependencyMap';
 import { handleDispatch } from './Dispatch';
 import * as DispatcherInstance from '../dispatcher/DispatcherInstance';
-import { isDispatcher } from '../dispatcher/DispatcherInterface';
+import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
 import invariant from 'invariant';
 
 type ReactMixin = {
@@ -40,11 +40,8 @@ export default function StoreDependencyMixin(
   dependencies: DependencyMap,
   dispatcher: ?Dispatcher = DispatcherInstance.get()
 ): ReactMixin {
-  invariant(
-    isDispatcher(dispatcher),
-    'expected `dispatcher` to be a `Flux.Dispatcher` but got `%s`',
-    dispatcher
-  );
+  enforceDispatcher(dispatcher);
+
   const dependencyIndex = makeDependencyIndex(dependencies);
 
   const mixin: ReactMixin = {

--- a/src/dependencies/__tests__/connectCallback-test.js
+++ b/src/dependencies/__tests__/connectCallback-test.js
@@ -91,8 +91,17 @@ describe('connect', () => {
   it('catches an exception in an update', (done) => {
     const mockError = new Error();
     let callbackCount = 0;
+    const errorCallback = jest.fn((error) => {
+      if (callbackCount > 0) {
+        expect(error).toBe(mockError);
+        done();
+      } else {
+        expect(error).toBe(null);
+        callbackCount++;
+      }
+    });
     let derefCount = 0;
-    connectCallback({
+    const errorDependencies = {
       test: {
         stores: [FirstStore],
         deref() {
@@ -103,16 +112,16 @@ describe('connect', () => {
           }
         },
       },
-    }, dispatcher)((error) => {
-      if (callbackCount > 0) {
-        expect(error).toBe(mockError);
-        done();
-      } else {
-        expect(error).toBe(null);
-        callbackCount++;
-      }
-    });
+    };
+    connectCallback(errorDependencies, dispatcher)(errorCallback);
     dispatcher.dispatch({actionType: ADD});
+    expect(errorCallback.mock.calls.length).toBe(2);
+    dispatcher.dispatch({actionType: ADD});
+    expect(errorCallback.mock.calls.length).toBe(2);
+  });
+
+  it('unregisters when an error occurs', () => {
+
   });
 
   it('unregisters when subscription.remove is called', () => {

--- a/src/dependencies/__tests__/connectCallback-test.js
+++ b/src/dependencies/__tests__/connectCallback-test.js
@@ -1,0 +1,88 @@
+jest.disableAutomock();
+import connectCallback from '../connectCallback';
+import { Dispatcher } from 'flux';
+import StoreFactory from '../../store/StoreFactory';
+
+describe('connect', () => {
+  const ADD = 'ADD';
+  const SUBTRACT = 'SUBTRACT';
+  const CountStoreFactory = new StoreFactory({})
+    .defineGet((state) => state)
+    .defineGetInitialState(() => 1)
+    .defineResponses({
+      [ADD]: (state) => state + 1,
+      [SUBTRACT]: (state) => state - 1,
+    });
+
+  let dispatcher;
+  let FirstStore;
+  let SecondStore;
+  let dependencies;
+  let callback;
+  let fakeProps;
+  let subscription;
+
+  beforeEach(() => {
+    callback = jest.fn();
+    fakeProps = {
+      add: 1,
+    };
+    dispatcher = new Dispatcher();
+    dispatcher.register = jest.fn(dispatcher.register);
+    dispatcher.unregister = jest.fn(dispatcher.unregister);
+    dispatcher.waitFor = jest.fn(dispatcher.waitFor);
+    FirstStore = CountStoreFactory.register(dispatcher);
+    SecondStore = CountStoreFactory.register(dispatcher);
+    dependencies = {
+      count: {
+        stores: [FirstStore, SecondStore],
+        deref(props) {
+          return FirstStore.get() + SecondStore.get() + props.add;
+        },
+      },
+    };
+    subscription = connectCallback(
+      dependencies,
+      dispatcher
+    )(
+      callback,
+      fakeProps
+    );
+  });
+
+  afterEach(() => {
+    subscription.remove();
+  });
+
+  it('recevies the available data immediately', () => {
+    expect(
+      callback.mock.calls[0][0]
+    ).toEqual({
+      count: 3
+    });
+  });
+
+  it('respondes to actions', () => {
+    dispatcher.dispatch({actionType: ADD});
+    expect(callback.mock.calls.length).toBe(2);
+    expect(
+      callback.mock.calls[1][0]
+    ).toEqual({
+      count: 5,
+    });
+    dispatcher.dispatch({actionType: SUBTRACT});
+    expect(callback.mock.calls.length).toBe(3);
+    expect(
+      callback.mock.calls[2][0]
+    ).toEqual({
+      count: 3,
+    });
+  });
+
+  it('unregisters when remove is called', () => {
+    subscription.remove();
+    expect(dispatcher.unregister.mock.calls.length).toBe(1);
+    dispatcher.dispatch({actionType: ADD});
+    expect(callback.mock.calls.length).toBe(1);
+  });
+});

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -10,8 +10,7 @@ import {
 } from '../dependencies/DependencyMap';
 import { handleDispatch } from './Dispatch';
 import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
-import { isDispatcher } from '../dispatcher/DispatcherInterface';
-import invariant from 'invariant';
+import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
 import React, { Component } from 'react';
 
 
@@ -30,11 +29,7 @@ export default function connect(
   dependencies: DependencyMap,
   dispatcher: ?Dispatcher = getDispatcherInstance()
 ): Function {
-  invariant(
-    isDispatcher(dispatcher),
-    'expected `dispatcher` to be a `Flux.Dispatcher` but got `%s`',
-    dispatcher
-  );
+  enforceDispatcher(dispatcher);
 
   const dependencyIndex = makeDependencyIndex(dependencies);
 

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -13,7 +13,6 @@ import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
 import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
 import React, { Component } from 'react';
 
-
 function transferStaticProperties(
   fromClass: Object,
   // By setting the type to Object, I'm doing a little dance around the type

--- a/src/dependencies/connectCallback.js
+++ b/src/dependencies/connectCallback.js
@@ -41,6 +41,7 @@ function subscribe(
       };
       callback(null, storeState, prevStoreState, remove);
     } catch (error) {
+      remove();
       callback(error, storeState, prevStoreState, remove);
     }
   }
@@ -58,6 +59,7 @@ function subscribe(
     storeState = calculateInitial(dependencies, props, state);
     callback(null, storeState, {}, remove);
   } catch (error) {
+    remove();
     callback(error, storeState, {}, remove);
   }
 

--- a/src/dependencies/connectCallback.js
+++ b/src/dependencies/connectCallback.js
@@ -1,0 +1,71 @@
+// @flow
+import type {
+  DependencyIndex,
+  DependencyIndexEntry,
+  DependencyMap,
+} from './DependencyMap';
+import {
+  calculateForDispatch,
+  calculateInitial,
+  makeDependencyIndex,
+} from '../dependencies/DependencyMap';
+import { handleDispatch } from './Dispatch';
+import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
+import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
+import type { Dispatcher } from 'flux';
+
+function subscribe(
+  dependencies: DependencyMap,
+  dependencyIndex: DependencyIndex,
+  dispatcher: Dispatcher,
+  callback: Function,
+  props: Object = {},
+  state: Object = {}
+) {
+  let prevState = calculateInitial(dependencies, props, state);
+
+  function handleUpdate(entry: DependencyIndexEntry) {
+    prevState = {
+      ...prevState,
+      ...calculateForDispatch(dependencies, entry, props, state),
+    };
+    callback(prevState);
+  }
+
+  let dispatchToken = dispatcher.register(
+    handleDispatch.bind(
+      null,
+      dispatcher,
+      dependencyIndex,
+      handleUpdate
+    )
+  );
+
+  callback(prevState);
+
+  return {
+    remove() {
+      if (dispatchToken) {
+        dispatcher.unregister(dispatchToken);
+        dispatchToken = null;
+      }
+    },
+  };
+}
+
+export default function connectCallback(
+  dependencies: DependencyMap,
+  dispatcher: ?Dispatcher = getDispatcherInstance()
+) {
+  enforceDispatcher(dispatcher);
+  if (!dispatcher) {
+    return null;
+  }
+
+  return subscribe.bind(
+    null,
+    dependencies,
+    makeDependencyIndex(dependencies),
+    dispatcher
+  );
+}

--- a/src/dispatcher/DispatcherInterface.js
+++ b/src/dispatcher/DispatcherInterface.js
@@ -1,5 +1,6 @@
 /* @flow */
 import type { Action, Dispatcher } from 'flux';
+import invariant from 'invariant';
 
 export function isDispatcher(dispatcher: ?Dispatcher): bool {
   return (
@@ -7,6 +8,16 @@ export function isDispatcher(dispatcher: ?Dispatcher): bool {
     typeof dispatcher === 'object' &&
     typeof dispatcher.register === 'function' &&
     typeof dispatcher.unregister === 'function'
+  );
+}
+
+export function enforceDispatcher(dispatcher: ?Dispatcher): void {
+  invariant(
+    isDispatcher(dispatcher),
+    'expected `dispatcher` to be a `Flux.Dispatcher` or compatible object but'
+      + 'got `%s` Learn more about the dispatcher interface:'
+      + ' https://github.com/HubSpot/general-store#dispatcher-interface',
+    dispatcher
   );
 }
 

--- a/src/store/InspectStore.js
+++ b/src/store/InspectStore.js
@@ -1,7 +1,8 @@
 /* @flow */
 import type { Dispatcher } from 'flux';
-import type Store, { StoreResponses } from './Store';
+import type { StoreResponses } from './Store';
 import type StoreFactory from './StoreFactory';
+import Store from './Store';
 
 export function getActionTypes(store: Store): Array<string> {
   return Object.keys(store._responses) || [];
@@ -37,4 +38,8 @@ export function getResponses(store: Store): StoreResponses {
 
 export function getState(store: Store) {
   return store._state;
+}
+
+export function isStore(store: any): bool {
+  return store instanceof Store;
 }

--- a/src/store/StoreFactory.js
+++ b/src/store/StoreFactory.js
@@ -1,7 +1,7 @@
 /* @flow */
 import type { Dispatcher } from 'flux';
 import * as DispatcherInstance from '../dispatcher/DispatcherInstance';
-import { isDispatcher } from '../dispatcher/DispatcherInterface.js';
+import { enforceDispatcher } from '../dispatcher/DispatcherInterface.js';
 import invariant from 'invariant';
 import Store from './Store';
 
@@ -147,14 +147,7 @@ export default class StoreFactory {
       ' instance.' +
       ' https://github.com/HubSpot/general-store#default-dispatcher-instance'
     );
-    invariant(
-      isDispatcher(dispatcher),
-      'StoreFactory.register: Expected dispatcher to be an object' +
-      ' with a register method, and an unregister method but got "%s".' +
-      ' Learn more about the dispatcher interface:' +
-      ' https://github.com/HubSpot/general-store#dispatcher-interface',
-      dispatcher
-    );
+    enforceDispatcher(dispatcher);
     const {getter, getInitialState, name, responses} = this._definition;
     return new Store({
       dispatcher,

--- a/src/store/__tests__/InspectStore-test.js
+++ b/src/store/__tests__/InspectStore-test.js
@@ -80,4 +80,9 @@ describe('InspectStore', () => {
   it('getState', () => {
     expect(InspectStore.getState(store)).toEqual({testing: 'yes'});
   });
+
+  it('isStore', () => {
+    expect(InspectStore.isStore({})).toBe(false);
+    expect(InspectStore.isStore(store)).toBe(true);
+  });
 });


### PR DESCRIPTION
Allows us to subscribe to dependencies outside of components. Uses node-style callback pattern that should be adaptable to various other async abstractions like Promises or Observables.

For example, implementing promise subscriptions might look like:

```javascript
function connectPromise(dependencies, isReady) {
  const resolver = connectCallback(dependencies);
  return function resolvePromise() {
    return Promise((resolve, reject) => {
      resolver((error, state, prevState, remove) => {
        if (error) {
          reject(error);
          return;
        }
        if (isReady(state)) {
          return;
        }
        resolve(state);
        remove();
      });
    });
  };
}
```

/cc @geoffdaigle @mattrheault 