### PR TITLE
ConnectedComponent has statics to dependencies and WrappedComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.2.2
 * connect adds a static `dependencies` field to the connected component
+* connect adds a static `WrappedComponent` field mirroring react-redux
 
 ## 2.2.1
 * Fix a potential bug in connect/StoreDependencyMixin that could cause an exeption in `componentWillUnmount`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.2
+* connect adds a static `dependencies` field to the connected component
+
 ## 2.2.1
 * Fix a potential bug in connect/StoreDependencyMixin that could cause an exeption in `componentWillUnmount`
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -1,8 +1,8 @@
 jest.disableAutomock();
-import { Dispatcher } from 'flux';
-import { shallow } from 'enzyme';
-import { getDispatchToken } from '../../store/InspectStore';
-import React, { PropTypes } from 'react';
+import {Dispatcher} from 'flux';
+import {shallow} from 'enzyme';
+import {getDispatchToken} from '../../store/InspectStore';
+import React, {PropTypes} from 'react';
 import connect from '../connect';
 import StoreFactory from '../../store/StoreFactory';
 
@@ -18,18 +18,18 @@ describe('connect', () => {
   const SECOND_ONLY = 'SECOND_ONLY';
   const SHARED = 'SHARED';
   const FirstStoreFactory = new StoreFactory({})
-    .defineGet((state) => state)
+    .defineGet(state => state)
     .defineGetInitialState(() => 1)
     .defineResponses({
-      [FIRST_ONLY]: (state) => state + 1,
-      [SHARED]: (state) => state - 1,
+      [FIRST_ONLY]: state => state + 1,
+      [SHARED]: state => state - 1,
     });
   const SecondStoreFactory = new StoreFactory({})
     .defineGet((state, add) => state + add)
     .defineGetInitialState(() => 2)
     .defineResponses({
-      [SECOND_ONLY]: (state) => state + 1,
-      [SHARED]: (state) => state - 1,
+      [SECOND_ONLY]: state => state + 1,
+      [SHARED]: state => state - 1,
     });
 
   let dispatcher;
@@ -55,34 +55,38 @@ describe('connect', () => {
           add: PropTypes.number,
         },
         stores: [SecondStore],
-        deref: (props) => SecondStore.get(props.add || 0),
+        deref: props => SecondStore.get(props.add || 0),
       },
       third: {
         stores: [FirstStore, SecondStore],
-        deref: (props) => {
+        deref: props => {
           return FirstStore.get() + SecondStore.get(props.add || 0);
-        }
-      }
+        },
+      },
     };
     MockComponent = connect(dependencies, dispatcher)(BaseComponent);
   });
 
   describe('statics', () => {
+    it('exports dependencies', () => {
+      expect(MockComponent.dependencies).toEqual(dependencies);
+    });
+
     it('generates a proper displayName', () => {
       expect(MockComponent.displayName).toBe('Connected(BaseComponent)');
     });
 
     it('passes any statics through to ConnectedComponent', () => {
       expect(typeof MockComponent.testStaticMethod).toBe('function');
-      expect(MockComponent.testStaticMethod).toBe(BaseComponent.testStaticMethod);
+      expect(MockComponent.testStaticMethod).toBe(
+        BaseComponent.testStaticMethod
+      );
     });
   });
 
   describe('propTypes', () => {
     it('has propTypes if a dependency specifices them', () => {
-      expect(
-        MockComponent.propTypes
-      ).toEqual({
+      expect(MockComponent.propTypes).toEqual({
         add: PropTypes.number,
       });
     });

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -72,6 +72,10 @@ describe('connect', () => {
       expect(MockComponent.dependencies).toEqual(dependencies);
     });
 
+    it('exports WrappedComponent', () => {
+      expect(MockComponent.WrappedComponent).toEqual(BaseComponent);
+    });
+
     it('generates a proper displayName', () => {
       expect(MockComponent.displayName).toBe('Connected(BaseComponent)');
     });

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -6,7 +6,7 @@ import {
   calculateForDispatch,
   calculateForPropsChange,
   dependencyPropTypes,
-  makeDependencyIndex
+  makeDependencyIndex,
 } from '../dependencies/DependencyMap';
 import {handleDispatch} from './Dispatch';
 import {get as getDispatcherInstance} from '../dispatcher/DispatcherInstance';
@@ -35,6 +35,8 @@ export default function connect(
   /* global ReactClass */
   return function connector(BaseComponent: ReactClass<*>): ReactClass<*> {
     class ConnectedComponent extends Component {
+      static dependencies: DependencyMap;
+
       /* eslint react/sort-comp: 0 */
       dispatchToken: ?string;
       state: Object;
@@ -84,6 +86,7 @@ export default function connect(
     }
 
     transferStaticProperties(BaseComponent, ConnectedComponent);
+    ConnectedComponent.dependencies = dependencies;
     ConnectedComponent.displayName = `Connected(${BaseComponent.displayName})`;
     ConnectedComponent.propTypes = dependencyPropTypes(
       dependencies,

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -36,6 +36,7 @@ export default function connect(
   return function connector(BaseComponent: ReactClass<*>): ReactClass<*> {
     class ConnectedComponent extends Component {
       static dependencies: DependencyMap;
+      static WrappedComponent: ReactClass<*>;
 
       /* eslint react/sort-comp: 0 */
       dispatchToken: ?string;
@@ -92,6 +93,7 @@ export default function connect(
       dependencies,
       BaseComponent.propTypes
     );
+    ConnectedComponent.WrappedComponent = BaseComponent;
 
     return ConnectedComponent;
   };


### PR DESCRIPTION
Adds two statics to the component created by `connect`. 

`dependencies` is a reference to the DependencyMap passed to connect.
`WrappedComponent` is a reference to the BaseComponent passed to connect.

Hopefully this'll make testing connected components easier.

One might render the wrapped component independently of the connect:

```jsx
<ConnectedComponent.WrappedComponent />
```

or test a component's dependencies independently of the component...

```
ConnectedComponent.dependencies[field].deref({});
```

**TODOs**
- [x] linter, checker, and test are passing
- [x] ~~any new public modules are exported from `src/GeneralStore.js`~~
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
