### PR TITLE
ConnectedComponent.focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.3
+* connect adds a `focus` method that calls through to `BaseComponent.focus`
+
 ## 2.2.2
 * connect adds a static `dependencies` field to the connected component
 * connect adds a static `WrappedComponent` field mirroring react-redux

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -1,6 +1,6 @@
 jest.disableAutomock();
 import { Dispatcher } from 'flux';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { getDispatchToken } from '../../store/InspectStore';
 import React, { PropTypes } from 'react';
 import connect from '../connect';
@@ -127,6 +127,33 @@ describe('connect', () => {
         two: 4,
         third: 5,
       });
+    });
+  });
+
+  describe('focus', () => {
+    it('is undefined if BaseComponent has no focus method', () => {
+      expect(MockComponent.focus).toBe(undefined);
+    });
+
+    it('calls through to the BaseComponents focus', () => {
+      const focusSpy = jest.fn();
+      class ComponentWithFocus extends React.Component {
+        focus(...args) {
+          return focusSpy(...args);
+        }
+
+        render() {
+          return <div />;
+        }
+      }
+      const ConnectedComponentWithFocus = connect(dependencies, dispatcher)(
+        ComponentWithFocus
+      );
+      const rendered = mount(<ConnectedComponentWithFocus />);
+      const connectedInstance = rendered.instance();
+      connectedInstance.focus('test', 123);
+      expect(focusSpy.mock.calls.length).toBe(1);
+      expect(focusSpy.mock.calls[0]).toEqual(['test', 123]);
     });
   });
 

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -1,6 +1,6 @@
 /* @flow */
-import type { DependencyIndexEntry, DependencyMap } from './DependencyMap';
-import type { Dispatcher } from 'flux';
+import type {DependencyIndexEntry, DependencyMap} from './DependencyMap';
+import type {Dispatcher} from 'flux';
 import {
   calculateInitial,
   calculateForDispatch,
@@ -8,10 +8,17 @@ import {
   dependencyPropTypes,
   makeDependencyIndex,
 } from '../dependencies/DependencyMap';
-import { handleDispatch } from './Dispatch';
-import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
-import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
-import React, { Component } from 'react';
+import {handleDispatch} from './Dispatch';
+import {get as getDispatcherInstance} from '../dispatcher/DispatcherInstance';
+import {enforceDispatcher} from '../dispatcher/DispatcherInterface';
+import React, {Component} from 'react';
+
+function focuser(instance, ...args) {
+  if (!instance.wrappedInstance) {
+    return undefined;
+  }
+  return instance.wrappedInstance.focus(...args);
+}
 
 function transferStaticProperties(
   fromClass: Object,
@@ -40,12 +47,8 @@ export default function connect(
 
       /* eslint react/sort-comp: 0 */
       dispatchToken: ?string;
-      state: Object;
-
-      constructor() {
-        super();
-        this.state = {};
-      }
+      state: Object = {};
+      wrappedInstance: ?Object = null;
 
       componentWillMount() {
         if (dispatcher) {
@@ -75,14 +78,28 @@ export default function connect(
         }
       }
 
+      focus = typeof BaseComponent.prototype.focus === 'function'
+        ? focuser.bind(this)
+        : undefined;
+
       handleDispatch(entry: DependencyIndexEntry) {
         this.setState(
           calculateForDispatch(dependencies, entry, this.props, this.state)
         );
       }
 
+      setWrappedInstance = ref => {
+        this.wrappedInstance = ref;
+      };
+
       render() {
-        return <BaseComponent {...this.props} {...this.state} />;
+        return (
+          <BaseComponent
+            {...this.props}
+            {...this.state}
+            ref={this.setWrappedInstance}
+          />
+        );
       }
     }
 

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -1,6 +1,6 @@
 /* @flow */
-import type {DependencyIndexEntry, DependencyMap} from './DependencyMap';
-import type {Dispatcher} from 'flux';
+import type { DependencyIndexEntry, DependencyMap } from './DependencyMap';
+import type { Dispatcher } from 'flux';
 import {
   calculateInitial,
   calculateForDispatch,
@@ -8,10 +8,10 @@ import {
   dependencyPropTypes,
   makeDependencyIndex,
 } from '../dependencies/DependencyMap';
-import {handleDispatch} from './Dispatch';
-import {get as getDispatcherInstance} from '../dispatcher/DispatcherInstance';
-import {enforceDispatcher} from '../dispatcher/DispatcherInterface';
-import React, {Component} from 'react';
+import { handleDispatch } from './Dispatch';
+import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
+import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
+import React, { Component } from 'react';
 
 function focuser(instance, ...args) {
   if (!instance.wrappedInstance) {
@@ -79,7 +79,7 @@ export default function connect(
       }
 
       focus = typeof BaseComponent.prototype.focus === 'function'
-        ? focuser.bind(this)
+        ? (...args) => focuser(this, ...args)
         : undefined;
 
       handleDispatch(entry: DependencyIndexEntry) {


### PR DESCRIPTION
Adds a focus method to `ConnectedComponent` when the `BaseComponent` has a focus method on its prototype.

This could probably be made more generic if it turns out there are other methods we want to call through to.

**TODOs**
- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
