### PR TITLE
connectWithState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+* `connectWithState` wraps a normal `connect` in a state container to fill the `StoreDependencyMixin` use case https://github.com/HubSpot/general-store/pull/55
+
 ## 2.2.3
 * connect adds a `focus` method that calls through to `BaseComponent.focus`
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "invariant": "^2.2.1",
     "jest-cli": "^12.1.1",
     "prettier": "^0.22.0",
+    "react": "^15.2.0",
     "react-addons-test-utils": "^15.2.0",
     "react-dom": "^15.2.0",
     "webpack": "^1.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "invariant": "^2.2.1",
     "jest-cli": "^12.1.1",
     "prettier": "^0.22.0",
-    "react": "^15.2.0",
     "react-addons-test-utils": "^15.2.0",
     "react-dom": "^15.2.0",
     "webpack": "^1.13.1"

--- a/src/GeneralStore.js
+++ b/src/GeneralStore.js
@@ -1,6 +1,7 @@
 /* @flow */
 import connect from './dependencies/connect';
 import connectCallback from './dependencies/connectCallback';
+import connectWithState from './dependencies/connectWithState';
 import * as DispatcherInstance from './dispatcher/DispatcherInstance';
 import * as InspectStore from './store/InspectStore';
 import StoreDependencyMixin from './dependencies/StoreDependencyMixin';
@@ -18,6 +19,7 @@ function defineFactory(): StoreFactory {
 module.exports = {
   connect,
   connectCallback,
+  connectWithState,
   define: defineSingleton,
   defineFactory,
   DispatcherInstance,

--- a/src/dependencies/BuildComponent.js
+++ b/src/dependencies/BuildComponent.js
@@ -1,0 +1,38 @@
+// @flow
+
+/* global ReactClass */
+export function makeDisplayName(
+  prefix: string,
+  BaseComponent: {displayName: string}
+) {
+  return `${prefix}(${BaseComponent.displayName})`;
+}
+
+export function focuser(instance: Object, ...args: Array<*>) {
+  if (
+    !instance.wrappedInstance ||
+    typeof instance.wrappedInstance.focus !== 'function'
+  ) {
+    return undefined;
+  }
+  return instance.wrappedInstance.focus(...args);
+}
+
+const reactStatics = {
+  defaultProps: true,
+  displayName: true,
+  getDefaultProps: true,
+  getInitialState: true,
+  propTypes: true,
+};
+
+export function transferNonReactStatics(
+  fromClass: Function,
+  toClass: Function
+) {
+  Object.keys(fromClass).forEach(staticField => {
+    if (!reactStatics[staticField]) {
+      toClass[staticField] = fromClass[staticField];
+    }
+  });
+}

--- a/src/dependencies/__tests__/BuildComponent-test.js
+++ b/src/dependencies/__tests__/BuildComponent-test.js
@@ -1,0 +1,49 @@
+jest.disableAutomock();
+import {
+  focuser,
+  makeDisplayName,
+  transferNonReactStatics,
+} from '../BuildComponent';
+
+describe('BuildComponent', () => {
+  describe('focuser', () => {
+    it('calls focus on wrappedInstance if it has a focus method', () => {
+      expect(() => focuser({wrappedInstance: {}})).not.toThrow();
+      const focus = jest.fn();
+      const fakeInstance = {
+        wrappedInstance: {focus},
+      };
+      focuser(fakeInstance, 'test', 123);
+      expect(focus.mock.calls[0]).toEqual(['test', 123]);
+    });
+  });
+
+  describe('makeDisplayName', () => {
+    it('creates a prefixed displayName', () => {
+      const BaseComponent = {displayName: 'BaseComponent'};
+      expect(makeDisplayName('Test', BaseComponent)).toBe(
+        'Test(BaseComponent)'
+      );
+    });
+  });
+
+  describe('transferNonReactStatics', () => {
+    it('copies static props from one constructor to another', () => {
+      const test = 'something else';
+      const Fn1 = () => {};
+      Fn1.test = test;
+      const Fn2 = () => {};
+      transferNonReactStatics(Fn1, Fn2);
+      expect(Fn2.test).toBe(test);
+    });
+
+    it('ignores react statics', () => {
+      const propTypes = {};
+      const Fn1 = () => {};
+      Fn1.propTypes = propTypes;
+      const Fn2 = () => {};
+      transferNonReactStatics(Fn1, Fn2);
+      expect(Fn2.propTypes).toBe(undefined);
+    });
+  });
+});

--- a/src/dependencies/__tests__/connectWithState-test.js
+++ b/src/dependencies/__tests__/connectWithState-test.js
@@ -1,0 +1,125 @@
+jest.disableAutomock();
+import connectWithState from '../connectWithState';
+import {Dispatcher} from 'flux';
+import {mount, shallow} from 'enzyme';
+import React from 'react';
+import StoreFactory from '../../store/StoreFactory';
+
+function BaseComponent() {
+  return <div />;
+}
+
+BaseComponent.displayName = 'BaseComponent';
+BaseComponent.testStaticMethod = () => true;
+
+describe('connect', () => {
+  const defaultInitialState = {testing: true};
+
+  const FIRST_ONLY = 'FIRST_ONLY';
+  const SHARED = 'SHARED';
+  const FirstStoreFactory = new StoreFactory({})
+    .defineGet(state => state)
+    .defineGetInitialState(() => 1)
+    .defineResponses({
+      [FIRST_ONLY]: state => state + 1,
+      [SHARED]: state => state - 1,
+    });
+
+  let dispatcher;
+  let dependencies;
+  let FirstStore;
+  let MockComponent;
+
+  beforeEach(() => {
+    dispatcher = new Dispatcher();
+    dispatcher.register = jest.fn(dispatcher.register);
+    dispatcher.unregister = jest.fn(dispatcher.unregister);
+    dispatcher.waitFor = jest.fn(dispatcher.waitFor);
+    FirstStore = FirstStoreFactory.register(dispatcher);
+    dependencies = {
+      one: {
+        stores: [FirstStore],
+        deref: () => FirstStore.get(),
+      },
+    };
+    MockComponent = connectWithState(
+      defaultInitialState,
+      dependencies,
+      dispatcher
+    )(BaseComponent);
+  });
+
+  describe('statics', () => {
+    it('exports dependencies', () => {
+      expect(MockComponent.dependencies).toEqual(dependencies);
+    });
+
+    it('exports WrappedComponent', () => {
+      expect(MockComponent.WrappedComponent).toEqual(BaseComponent);
+    });
+
+    it('generates a proper displayName', () => {
+      expect(MockComponent.displayName).toBe(
+        'Stateful(Connected(BaseComponent))'
+      );
+    });
+
+    it('passes any statics through to ConnectedComponent', () => {
+      expect(typeof MockComponent.testStaticMethod).toBe('function');
+      expect(MockComponent.testStaticMethod).toBe(
+        BaseComponent.testStaticMethod
+      );
+    });
+  });
+
+  describe('focus', () => {
+    it('is undefined if BaseComponent has no focus method', () => {
+      expect(MockComponent.focus).toBe(undefined);
+    });
+
+    it('calls through to the BaseComponents focus', () => {
+      const focusSpy = jest.fn();
+      class ComponentWithFocus extends React.Component {
+        focus(...args) {
+          return focusSpy(...args);
+        }
+
+        render() {
+          return <div />;
+        }
+      }
+      const ConnectedComponentWithFocus = connectWithState(
+        defaultInitialState,
+        dependencies,
+        dispatcher
+      )(ComponentWithFocus);
+      const rendered = mount(<ConnectedComponentWithFocus />);
+      const connectedInstance = rendered.instance();
+      connectedInstance.focus('test', 123);
+      expect(focusSpy.mock.calls.length).toBe(1);
+      expect(focusSpy.mock.calls[0]).toEqual(['test', 123]);
+    });
+  });
+
+  describe('initialState', () => {
+    it('passes defaultInitialState if no initialState is specified', () => {
+      const rendered = shallow(<MockComponent />);
+      expect(rendered.prop('initialState')).toEqual(defaultInitialState);
+    });
+
+    it('passes initialState if it is specified', () => {
+      const initialState = {testing: false};
+      const rendered = shallow(<MockComponent initialState={initialState} />);
+      expect(rendered.prop('initialState')).toEqual(initialState);
+    });
+  });
+
+  describe('state', () => {
+    it('updates state', () => {
+      const rendered = shallow(<MockComponent />);
+      expect(rendered.prop('state')).toEqual(defaultInitialState);
+      rendered.prop('setState')({testing: false});
+      expect(rendered.prop('state')).toEqual({testing: false});
+    });
+  });
+});

--- a/src/dependencies/connectWithState.js
+++ b/src/dependencies/connectWithState.js
@@ -1,0 +1,75 @@
+// @flow
+import {
+  makeDisplayName,
+  focuser,
+  transferNonReactStatics,
+} from './BuildComponent';
+import connect from './connect';
+import type {DependencyMap} from './DependencyMap';
+import {get as getDispatcherInstance} from '../dispatcher/DispatcherInstance';
+import type {Dispatcher} from 'flux';
+import React, {Component, PropTypes} from 'react';
+
+/* global ReactClass */
+function connector(
+  defaultInitialState: Object,
+  dependencies: DependencyMap,
+  depConnector: (BaseComponent: ReactClass<*>) => ReactClass<*>,
+  BaseComponent: ReactClass<*>
+) {
+  const ConnectedComponent = depConnector(BaseComponent);
+  class ConnectedComponentWithState extends Component {
+    static displayName = makeDisplayName('Stateful', ConnectedComponent);
+    static propTypes = {
+      ...ConnectedComponent.propTypes,
+      setState: undefined,
+      state: undefined,
+      initialState: PropTypes.object,
+    };
+    static WrappedComponent = BaseComponent;
+    static wrappedInstance: ?Object = null;
+
+    state = this.props.initialState || defaultInitialState;
+    wrappedInstance: ?Object;
+
+    boundSetState = this.setState.bind(this);
+
+    focus = typeof BaseComponent.prototype.focus === 'function'
+      ? (...args) => focuser(this, ...args)
+      : undefined;
+
+    setWrappedInstance = ref => {
+      this.wrappedInstance = ref;
+    };
+
+    render() {
+      const {initialState, ...props} = this.props;
+      return (
+        <ConnectedComponent
+          {...props}
+          initialState={initialState || defaultInitialState}
+          ref={this.setWrappedInstance}
+          setState={this.boundSetState}
+          state={this.state}
+        />
+      );
+    }
+  }
+
+  transferNonReactStatics(ConnectedComponent, ConnectedComponentWithState);
+
+  return ConnectedComponentWithState;
+}
+
+export default function connectWithState(
+  defaultInitialState: Object = {},
+  dependencies: DependencyMap,
+  dispatcher: ?Dispatcher = getDispatcherInstance()
+) {
+  return connector.bind(
+    null,
+    defaultInitialState,
+    dependencies,
+    connect(dependencies, dispatcher)
+  );
+}


### PR DESCRIPTION
`connectWithState` aims to fill the remaining use case for `StoreDependencyMixin` (i.e. dependencies that are resolved with state).

```js
const initialState = {
  postId: 1,
};

const dependencies = {
  post: {
    stores: [PostStore],
    deref({state}) {
     return PostStore.get(state.postId);
    }
  }
};

function ShowPost({post, setState, state}) {
  return (
    <div>
      {post.description}
      <button onClick={() => setState({postId: state.postId + 1})}>
        Next post
      </button>
    </div>
  );
}

export default connectWithState(initialState, dependencies)(ShowPost);
```

**TODOs**
- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
