### PR TITLE
fix displayName of connected components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.2
+* fixes the name that developer tools show for wrapped components that don't have displayName attributes (eg `Connected(undefined)` is now `Connected(BaseComponent)`)
+
 ## 2.3.1
 * `connectWithState` no longer exports invalid propTypes
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/dependencies/BuildComponent.js
+++ b/src/dependencies/BuildComponent.js
@@ -5,7 +5,8 @@ export function makeDisplayName(
   prefix: string,
   BaseComponent: { displayName: string }
 ) {
-  return `${prefix}(${BaseComponent.displayName})`;
+  const baseComponentName = BaseComponent.displayName || BaseComponent.name;
+  return `${prefix}(${baseComponentName})`;
 }
 
 export function focuser(instance: Object, ...args: Array<*>) {

--- a/src/dependencies/BuildComponent.js
+++ b/src/dependencies/BuildComponent.js
@@ -3,7 +3,7 @@
 /* global ReactClass */
 export function makeDisplayName(
   prefix: string,
-  BaseComponent: { displayName: string }
+  BaseComponent: { displayName?: string, name?: string }
 ) {
   const baseComponentName = BaseComponent.displayName || BaseComponent.name;
   return `${prefix}(${baseComponentName})`;

--- a/src/dependencies/BuildComponent.js
+++ b/src/dependencies/BuildComponent.js
@@ -5,7 +5,7 @@ export function makeDisplayName(
   prefix: string,
   BaseComponent: { displayName?: string, name?: string }
 ) {
-  const baseComponentName = BaseComponent.displayName || BaseComponent.name;
+  const baseComponentName = BaseComponent.displayName || BaseComponent.name || 'Component';
   return `${prefix}(${baseComponentName})`;
 }
 

--- a/src/dependencies/__tests__/BuildComponent-test.js
+++ b/src/dependencies/__tests__/BuildComponent-test.js
@@ -19,10 +19,24 @@ describe('BuildComponent', () => {
   });
 
   describe('makeDisplayName', () => {
-    it('creates a prefixed displayName', () => {
-      const BaseComponent = { displayName: 'BaseComponent' };
+    it('creates a prefixed displayName using BaseComponent.displayName', () => {
+      const BaseComponent = { displayName: 'BaseComponentDisplayName' };
+      expect(makeDisplayName('Test', BaseComponent)).toBe(
+        'Test(BaseComponentDisplayName)'
+      );
+    });
+
+    it('creates a prefixed displayName using Function.name', () => {
+      const BaseComponent = () => {};
       expect(makeDisplayName('Test', BaseComponent)).toBe(
         'Test(BaseComponent)'
+      );
+    });
+
+    it('creates a prefixed displayName using a fallback if necessary', () => {
+      const BaseComponent = {};
+      expect(makeDisplayName('Test', BaseComponent)).toBe(
+        'Test(Component)'
       );
     });
   });


### PR DESCRIPTION
![screen shot 2017-08-15 at 11 36 26 am](https://user-images.githubusercontent.com/693878/29323194-28d990c2-81ae-11e7-9422-207e3126bbf7.png)

Sometimes when using general-store you see components named "Connected(undefined)" when you'd expect "Connected(MyRealComponentName)". general-store does the right thing React createClass-style components which expose a `displayName` prop, but not for plain javascript functions and classes. Those things expose [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name). I think that making this change will fix that. 

I'm opening this PR as a reminder for myself, if it sounds good then I can add unit tests and a changelog line.

**TODOs**
- [x] linter, checker, and test are passing
- [x] THEO ADD A NEW UNIT TEST PLEASE
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
