### PR TITLE
Allow general-store to connect to redux chrome extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.0
+* Adds the ability to use the [Redux Devtools Extension](https://github.com/zalmoxisus/redux-devtools-extension/) to inspect the state of stores.
+
 ## 2.3.2
 * fixes the name that developer tools show for wrapped components that don't have displayName attributes (eg `Connected(undefined)` is now `Connected(BaseComponent)`)
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ type Dispatcher = {
 ```
 ## Redux Devtools Extension
 
-Using [Redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) you can inspect the state of a store and see how the state changes between dispatches. The "Jump" feature should work but it is dependent on you using regular JS objects as the backing state.
+Using [Redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) you can inspect the state of a store and see how the state changes between dispatches. The "Jump" (ability to change store state to what it was after a specific dispatch) feature should work but it is dependent on you using regular JS objects as the backing state.
 
 Using the `defineFactory` way of creating stores is highly recommended for this integration as you can define a name for your store and always for the state of the store to be inspected programmatically.
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ type Dispatcher = {
   waitFor: (dispatchTokens: Array<string>) => void;
 };
 ```
+## Redux Devtools Extension
+
+Using [Redux devtools extension](https://github.com/zalmoxisus/redux-devtools-extension) you can inspect the state of a store and see how the state changes between dispatches. The "Jump" feature should work but it is dependent on you using regular JS objects as the backing state.
+
+Using the `defineFactory` way of creating stores is highly recommended for this integration as you can define a name for your store and always for the state of the store to be inspected programmatically.
 
 ## Build and test
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -89,9 +89,10 @@ export default class Store {
       this._unsubscribeDevTools = this._devToolsExtension.subscribe(message => {
         if (
           message.type === 'DISPATCH' &&
-          message.payload.type === 'JUMP_TO_STATE'
+          message.payload.type === 'JUMP_TO_ACTION'
         ) {
-          this._handleDispatch(message.payload);
+          this._state = JSON.parse(message.state);
+          this.triggerChange();
         }
       });
     }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,9 +1,9 @@
 /* eslint no-console:0 */
 /* @flow */
-import type { Action, Dispatcher } from 'flux';
+import type {Action, Dispatcher} from 'flux';
 import type StoreFactory from './StoreFactory';
 
-import { isPayload } from '../dispatcher/DispatcherInterface.js';
+import {isPayload} from '../dispatcher/DispatcherInterface.js';
 import Event from '../event/Event.js';
 import EventHandler from '../event/EventHandler.js';
 import invariant from 'invariant';
@@ -12,7 +12,8 @@ import uniqueID from '../uniqueid/uniqueID.js';
 const HINT_LINK = 'Learn more about using the Store API:' +
   ' https://github.com/HubSpot/general-store#using-the-store-api';
 
-const hasReduxDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__;
+const hasReduxDevTools = typeof window !== 'undefined' &&
+  window.__REDUX_DEVTOOLS_EXTENSION__;
 
 function getNull() {
   return null;
@@ -38,6 +39,11 @@ type StoreOptions = {
   responses: {},
 };
 
+type DevToolsExtension = {
+  send: (string, any) => any,
+  disconnect: () => any,
+};
+
 export default class Store {
   _dispatcher: Dispatcher;
   _dispatchToken: string;
@@ -48,6 +54,8 @@ export default class Store {
   _responses: StoreResponses;
   _state: any;
   _uid: string;
+  _devToolsExtension: DevToolsExtension;
+  _unsubscribeDevTools: ?() => any;
 
   constructor(
     {
@@ -75,15 +83,15 @@ export default class Store {
     if (hasReduxDevTools) {
       this._devToolsExtension = window.__REDUX_DEVTOOLS_EXTENSION__.connect({
         name: `${this._name}_${this._uid}`,
-        instanceId: this._uid
+        instanceId: this._uid,
       });
 
-      this._unsubscribe = this._devToolsExtension.subscribe(message => {
+      this._unsubscribeDevTools = this._devToolsExtension.subscribe(message => {
         if (
           message.type === 'DISPATCH' &&
           message.payload.type === 'JUMP_TO_STATE'
         ) {
-          this._handleDispatch(message.payload)
+          this._handleDispatch(message.payload);
         }
       });
     }
@@ -160,8 +168,10 @@ export default class Store {
     this._getter = getNull;
     this._responses = {};
 
-    typeof this._unsubscribe === 'function' && this._unsubscribe();
-    typeof this._devToolsExtension !== 'undefined' && this._devToolsExtension.disconnect();
+    typeof this._unsubscribeDevTools === 'function' &&
+      this._unsubscribeDevTools();
+    typeof this._devToolsExtension !== 'undefined' &&
+      this._devToolsExtension.disconnect();
   }
 
   toString(): string {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,9 +1,9 @@
 /* eslint no-console:0 */
 /* @flow */
-import type {Action, Dispatcher} from 'flux';
+import type { Action, Dispatcher } from 'flux';
 import type StoreFactory from './StoreFactory';
 
-import {isPayload} from '../dispatcher/DispatcherInterface.js';
+import { isPayload } from '../dispatcher/DispatcherInterface.js';
 import Event from '../event/Event.js';
 import EventHandler from '../event/EventHandler.js';
 import invariant from 'invariant';
@@ -54,7 +54,7 @@ export default class Store {
   _responses: StoreResponses;
   _state: any;
   _uid: string;
-  _devToolsExtension: DevToolsExtension;
+  _devToolsExtension: ?DevToolsExtension;
   _unsubscribeDevTools: ?() => any;
 
   constructor(
@@ -82,7 +82,7 @@ export default class Store {
 
     if (hasReduxDevTools) {
       this._devToolsExtension = window.__REDUX_DEVTOOLS_EXTENSION__.connect({
-        name: `${this._name}_${this._uid}`,
+        name: name || `Store_${this._uid}`,
         instanceId: this._uid,
       });
 

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -54,7 +54,7 @@ export default class Store {
   _responses: StoreResponses;
   _state: any;
   _uid: string;
-  _devToolsExtension: ?DevToolsExtension;
+  _devToolsExtension: DevToolsExtension;
   _unsubscribeDevTools: ?() => any;
 
   constructor(


### PR DESCRIPTION
@colbyr @marcneuwirth @theopak 

This allows us to connect to the usual Redux chrome extension using its API. Thoughts on this approach? 

Hooking into one of our stores 
"Diff" view
<img width="1303" alt="screenshot 2017-11-24 03 13 19" src="https://user-images.githubusercontent.com/4588318/33201216-94138300-d0c5-11e7-9fc0-167a81eceac6.png">

"State" view (You can see the state at each action)
<img width="1303" alt="screenshot 2017-11-24 03 14 11" src="https://user-images.githubusercontent.com/4588318/33201217-9433c9e4-d0c5-11e7-9b27-64941e6abb7a.png">

Each store would have its own instance in the dropdown letting you dive into each store individually. 
<img width="1303" alt="screenshot 2017-11-24 03 16 10" src="https://user-images.githubusercontent.com/4588318/33201289-d9469d5e-d0c5-11e7-806f-19c59ee8060f.png">

The "dispatcher" view is my little way of seeing all dispatches going through but may not be acted on. That code would live inside the app. 

**TODOs**
- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
