### PR TITLE
Use unsubscribe method instead of disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.1
+* Fixes the function as the latest version of the extension uses `unsubscribe` instead of `disconnect`.
+
 ## 2.4.0
 * Adds the ability to use the [Redux Devtools Extension](https://github.com/zalmoxisus/redux-devtools-extension/) to inspect the state of stores.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -41,7 +41,7 @@ type StoreOptions = {
 
 type DevToolsExtension = {
   send: (string, any) => any,
-  disconnect: () => any,
+  unsubscribe: () => any,
 };
 
 export default class Store {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -172,7 +172,7 @@ export default class Store {
     typeof this._unsubscribeDevTools === 'function' &&
       this._unsubscribeDevTools();
     typeof this._devToolsExtension !== 'undefined' &&
-      this._devToolsExtension.disconnect();
+      this._devToolsExtension.unsubscribe();
   }
 
   toString(): string {


### PR DESCRIPTION
Thanks to @zsobin for pointing this out. 

@colbyr 

**TODOs**
- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
