### PR TITLE
support defineName on GeneralStore.define() stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.0
+* Stores created with `GeneralStore.define()` support `defineName`
+
 ## 2.4.1
 * Fixes the function as the latest version of the extension uses `unsubscribe` instead of `disconnect`.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/store/StoreSingleton.js
+++ b/src/store/StoreSingleton.js
@@ -47,6 +47,11 @@ export default class StoreSingleton {
     return this;
   }
 
+  defineName(name: string): StoreSingleton {
+    this._factory.defineName(name);
+    return this;
+  }
+
   defineResponseTo(
     actionTypes: Array<string> | string,
     response: (data: any) => void

--- a/src/store/__tests__/StoreSingleton-test.js
+++ b/src/store/__tests__/StoreSingleton-test.js
@@ -31,6 +31,13 @@ describe('StoreSingleton', () => {
     expect(() => storeDefinition.defineGet(EMPTY_FUNC)).not.toThrow();
   });
 
+  it('calls through to defineName on the factory', () => {
+    const storeName = 'TestStore';
+    spyOn(storeDefinition._factory, 'defineName');
+    storeDefinition.defineName(storeName);
+    expect(storeDefinition._factory.defineName).toHaveBeenCalledWith(storeName);
+  });
+
   it('throws if define* are called after register', () => {
     storeDefinition.defineGet(EMPTY_FUNC).register(mockDispatcher);
     expect(() =>


### PR DESCRIPTION
Fixes #60 

**TODOs**
- [x] linter, checker, and test are passing
- [x] ~any new public modules are exported from `src/GeneralStore.js`~
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
