### PR TITLE
use hoist-non-react-statics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.1
+* Support React 16.x by using [hoist-non-react-statics@2.5.0](https://github.com/mridgway/hoist-non-react-statics) (without `ForwardRef` support)
+
 ## 2.5.0
 * Stores created with `GeneralStore.define()` support `defineName`
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "homepage": "https://github.com/HubSpot/general-store",
   "authors": [
     "Colby Rabideau <crabideau@hubspot.com>"

--- a/flow-typed/hoist-non-react-statics.js
+++ b/flow-typed/hoist-non-react-statics.js
@@ -1,0 +1,3 @@
+declare module 'hoist-non-react-statics' {
+  declare module.exports: any;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
       "<rootDir>/src/uniqueid",
       "<rootDir>/src/utils/ObjectUtils.js"
     ]
+  },
+  "dependencies": {
+    "hoist-non-react-statics": "^2.5.0"
   }
 }

--- a/src/dependencies/BuildComponent.js
+++ b/src/dependencies/BuildComponent.js
@@ -18,22 +18,3 @@ export function focuser(instance: Object, ...args: Array<*>) {
   }
   return instance.wrappedInstance.focus(...args);
 }
-
-const reactStatics = {
-  defaultProps: true,
-  displayName: true,
-  getDefaultProps: true,
-  getInitialState: true,
-  propTypes: true,
-};
-
-export function transferNonReactStatics(
-  fromClass: Function,
-  toClass: Function
-) {
-  Object.keys(fromClass).forEach(staticField => {
-    if (!reactStatics[staticField]) {
-      toClass[staticField] = fromClass[staticField];
-    }
-  });
-}

--- a/src/dependencies/__tests__/BuildComponent-test.js
+++ b/src/dependencies/__tests__/BuildComponent-test.js
@@ -2,7 +2,6 @@ jest.disableAutomock();
 import {
   focuser,
   makeDisplayName,
-  transferNonReactStatics,
 } from '../BuildComponent';
 
 describe('BuildComponent', () => {
@@ -38,26 +37,6 @@ describe('BuildComponent', () => {
       expect(makeDisplayName('Test', BaseComponent)).toBe(
         'Test(Component)'
       );
-    });
-  });
-
-  describe('transferNonReactStatics', () => {
-    it('copies static props from one constructor to another', () => {
-      const test = 'something else';
-      const Fn1 = () => {};
-      Fn1.test = test;
-      const Fn2 = () => {};
-      transferNonReactStatics(Fn1, Fn2);
-      expect(Fn2.test).toBe(test);
-    });
-
-    it('ignores react statics', () => {
-      const propTypes = {};
-      const Fn1 = () => {};
-      Fn1.propTypes = propTypes;
-      const Fn2 = () => {};
-      transferNonReactStatics(Fn1, Fn2);
-      expect(Fn2.propTypes).toBe(undefined);
     });
   });
 });

--- a/src/dependencies/connect.js
+++ b/src/dependencies/connect.js
@@ -4,7 +4,6 @@ import type { Dispatcher } from 'flux';
 import {
   makeDisplayName,
   focuser,
-  transferNonReactStatics,
 } from './BuildComponent';
 import {
   calculateInitial,
@@ -17,6 +16,7 @@ import { handleDispatch } from './Dispatch';
 import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
 import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
 import React, { Component } from 'react';
+import hoistStatics from 'hoist-non-react-statics'
 
 export default function connect(
   dependencies: DependencyMap,
@@ -96,8 +96,6 @@ export default function connect(
       }
     }
 
-    transferNonReactStatics(BaseComponent, ConnectedComponent);
-
-    return ConnectedComponent;
+    return hoistStatics(ConnectedComponent, BaseComponent);
   };
 }

--- a/src/dependencies/connectWithState.js
+++ b/src/dependencies/connectWithState.js
@@ -2,13 +2,13 @@
 import {
   makeDisplayName,
   focuser,
-  transferNonReactStatics,
 } from './BuildComponent';
 import connect from './connect';
 import type { DependencyMap } from './DependencyMap';
 import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
 import type { Dispatcher } from 'flux';
 import React, { Component, PropTypes } from 'react';
+import hoistStatics from 'hoist-non-react-statics'
 
 /* global ReactClass */
 function connector(
@@ -58,9 +58,7 @@ function connector(
     }
   }
 
-  transferNonReactStatics(ConnectedComponent, ConnectedComponentWithState);
-
-  return ConnectedComponentWithState;
+  return hoistStatics(ConnectedComponentWithState, ConnectedComponent);
 }
 
 export default function connectWithState(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,6 +1934,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"


### PR DESCRIPTION
This change is to use `hoist-non-react-statics` to fix code that was causing a warning with React 16.

> `Warning: Connected(...).childContextTypes is specified bu there is no getChildContext() method on the instance. You can either define getChildContext() on Connected(...) or remove childContextTypes from it.`

@Friss 

**TODOs**
- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json` and `bower.json`
- [x] `CHANGELOG.md` is up to date
