### PR TITLE
externalize hoist-non-react-statics from rollup bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+* Externalize `hoist-non-react-statics` from CJS and ESM bundles.
+
 ## 3.0.0
 * Removes the following APIs
   * `StoreDependencyMixin`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -60,7 +60,7 @@ const moduleBundleConfig = {
       format: 'esm',
     },
   ],
-  external: ['react'],
+  external: ['react', 'hoist-non-react-statics'],
 };
 
 export default [


### PR DESCRIPTION
This should help prevent `hoist-non-react-statics` and `react-is` from being bundled multiple times in  apps.