### PR TITLE
Support arrow function components

### DIFF
--- a/src/dependencies/__tests__/BuildComponent-test.js
+++ b/src/dependencies/__tests__/BuildComponent-test.js
@@ -1,8 +1,5 @@
 jest.disableAutomock();
-import {
-  focuser,
-  makeDisplayName,
-} from '../BuildComponent';
+import { focuser, makeDisplayName } from '../BuildComponent';
 
 describe('BuildComponent', () => {
   describe('focuser', () => {
@@ -34,9 +31,7 @@ describe('BuildComponent', () => {
 
     it('creates a prefixed displayName using a fallback if necessary', () => {
       const BaseComponent = {};
-      expect(makeDisplayName('Test', BaseComponent)).toBe(
-        'Test(Component)'
-      );
+      expect(makeDisplayName('Test', BaseComponent)).toBe('Test(Component)');
     });
   });
 });

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -17,6 +17,10 @@ function BaseComponent() {
 BaseComponent.displayName = 'BaseComponent';
 BaseComponent.testStaticMethod = () => true;
 
+const BaseArrowComponent = () => {
+  return <div />;
+};
+
 describe('connect', () => {
   const FIRST_ONLY = 'FIRST_ONLY';
   const SECOND_ONLY = 'SECOND_ONLY';
@@ -41,6 +45,7 @@ describe('connect', () => {
   let SecondStore;
   let dependencies;
   let MockComponent;
+  let MockArrowComponent;
 
   beforeEach(() => {
     dispatcher = new Dispatcher();
@@ -72,19 +77,29 @@ describe('connect', () => {
       dependencies,
       dispatcher
     )(BaseComponent);
+
+    MockArrowComponent = connect(
+      dependencies,
+      dispatcher
+    )(BaseArrowComponent);
   });
 
   describe('statics', () => {
     it('exports dependencies', () => {
       expect(MockComponent.dependencies).toEqual(dependencies);
+      expect(MockArrowComponent.dependencies).toEqual(dependencies);
     });
 
     it('exports WrappedComponent', () => {
       expect(MockComponent.WrappedComponent).toEqual(BaseComponent);
+      expect(MockArrowComponent.WrappedComponent).toEqual(BaseArrowComponent);
     });
 
     it('generates a proper displayName', () => {
       expect(MockComponent.displayName).toBe('Connected(BaseComponent)');
+      expect(MockArrowComponent.displayName).toBe(
+        'Connected(BaseArrowComponent)'
+      );
     });
 
     it('passes any statics through to ConnectedComponent', () => {
@@ -109,6 +124,15 @@ describe('connect', () => {
           dispatcher
         )(BaseComponent).propTypes
       ).toEqual({});
+    });
+  });
+
+  describe('renders', () => {
+    it('renders without error', () => {
+      const rootArrow = mount(<MockArrowComponent />);
+      expect(rootArrow.exists()).toBe(true);
+      const root = mount(<MockComponent />);
+      expect(root.exists()).toBe(true);
     });
   });
 
@@ -143,6 +167,7 @@ describe('connect', () => {
   describe('focus', () => {
     it('is undefined if BaseComponent has no focus method', () => {
       expect(MockComponent.focus).toBe(undefined);
+      expect(MockArrowComponent.focus).toBe(undefined);
     });
 
     it('calls through to the BaseComponents focus', () => {

--- a/src/dependencies/connect.tsx
+++ b/src/dependencies/connect.tsx
@@ -70,7 +70,7 @@ export default function connect(
       }
 
       focus =
-        typeof BaseComponent.prototype.focus === 'function'
+        BaseComponent.prototype && typeof BaseComponent.prototype.focus === 'function'
           ? (...args) => focuser(this, ...args)
           : undefined;
 
@@ -85,11 +85,13 @@ export default function connect(
       };
 
       render() {
+        const refProp = !!(BaseComponent.prototype && BaseComponent.prototype.isReactComponent) ? {ref: this.setWrappedInstance} : {};
+
         return (
           <BaseComponent
             {...this.props}
             {...this.state}
-            ref={this.setWrappedInstance}
+            {...refProp}
           />
         );
       }


### PR DESCRIPTION
@colbyr @henryqdineen @aem @akutch 

This is an attempt at solving #66 

Since Arrow function components don't have a `prototype` it guards the check for `focus` and then it avoids the error that Function components can't be given refs. 

```
 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

      Check the render method of `Connected(BaseArrowComponent)`.
          in BaseArrowComponent (created by Connected(BaseArrowComponent))
          in Connected(BaseArrowComponent) (created by WrapperComponent)
          in WrapperComponent
```

I used React's internal check for a functional component [Blog](https://overreacted.io/how-does-react-tell-a-class-from-a-function/) 

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [ ] version numbers are up to date in `package.json`
- [ ] `CHANGELOG.md` is up to date
