### PR TITLE
Use unsafe prefix method names'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+* Use `UNSAFE_` prefix for `componentWillMount`, `componentWillReceiveProps` usages in `connect` HOC.
+
 ## 3.0.1
 * Externalize `hoist-non-react-statics` from CJS and ESM bundles.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -112,7 +112,7 @@ describe('connect', () => {
     });
   });
 
-  describe('componentWillMount', () => {
+  describe('UNSAFE_componentWillMount', () => {
     it('registers a callback with the dispatcher', () => {
       shallow(<MockComponent />);
       expect(dispatcher.register.mock.calls.length).toEqual(3);
@@ -128,7 +128,7 @@ describe('connect', () => {
     });
   });
 
-  describe('componentWillReceiveProps', () => {
+  describe('UNSAFE_componentWillReceiveProps', () => {
     it('calculates and sets state', () => {
       const root = shallow(<MockComponent />);
       root.setProps({ add: 2 });

--- a/src/dependencies/connect.tsx
+++ b/src/dependencies/connect.tsx
@@ -41,7 +41,7 @@ export default function connect(
       state: any = {};
       wrappedInstance?: HTMLElement = null;
 
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         if (dispatcher) {
           this.dispatchToken = dispatcher.register(
             handleDispatch.bind(
@@ -55,7 +55,7 @@ export default function connect(
         this.setState(calculateInitial(dependencies, this.props, this.state));
       }
 
-      componentWillReceiveProps(nextProps: Object) {
+      UNSAFE_componentWillReceiveProps(nextProps: Object) {
         this.setState(
           calculateForPropsChange(dependencies, nextProps, this.state)
         );


### PR DESCRIPTION
@colbyr @aem @henryqdineen 

Resolves the warnings about not using the `UNSAFE_` prefix methods. Shouldn't be an issue to move over to this now that React >= 16.8 is a peerDep. 

(I wanted to silence this warning in a personal project but will work for us at HubSpot as well)

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json`
- [x] `CHANGELOG.md` is up to date
