### PR TITLE
fix(useStoreDependency): use shallowCompare to compare results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+* Fix potential infinite loop with Immutable dependency values (#74)
+
 ## 3.1.0
 * Use `UNSAFE_` prefix for `componentWillMount`, `componentWillReceiveProps` usages in `connect` HOC.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-react-app": "^4.0.1",
     "eslint-plugin-react-hooks": "^1.5.1",
     "flux": "^2.0.1",
+    "immutable": "4.0.0-rc.12",
     "immutable-is": "^3.7.4",
     "invariant": "^2.2.1",
     "jest": "24.5.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-react-app": "^4.0.1",
     "eslint-plugin-react-hooks": "^1.5.1",
     "flux": "^2.0.1",
-    "immutable": "4.0.0-rc.12",
+    "immutable": "3.8.1",
     "immutable-is": "^3.7.4",
     "invariant": "^2.2.1",
     "jest": "24.5.0",

--- a/src/dependencies/__tests__/useStoreDependency-test.js
+++ b/src/dependencies/__tests__/useStoreDependency-test.js
@@ -182,6 +182,7 @@ describe('useStoreDependency', () => {
       // not implemented correctly, as the immutables will not be strictly
       // equal, sending useStoreDependency into an infinite loop
       // https://github.com/HubSpot/general-store/issues/74
+      expect(true).toBe(true);
     });
   });
 

--- a/src/dependencies/useStoreDependency.ts
+++ b/src/dependencies/useStoreDependency.ts
@@ -10,6 +10,7 @@ import { get as getDispatcherInstance } from '../dispatcher/DispatcherInstance';
 import { enforceDispatcher } from '../dispatcher/DispatcherInterface';
 import { handleDispatch } from './Dispatch';
 import { Dispatcher } from 'flux';
+import { shallowEqual } from '../utils/ObjectUtils';
 
 type SingleDependency = {
   [key: string]: Dependency;
@@ -50,7 +51,7 @@ function useStoreDependency<Props>(
             entry,
             currProps.current
           );
-          if (newValue !== dependencyValue) {
+          if (!shallowEqual(newValue, dependencyValue)) {
             setDependencyValue(newValue);
           }
         }
@@ -62,7 +63,7 @@ function useStoreDependency<Props>(
   }, [dispatcher, dependencyValue, dependency, currProps]);
 
   const newValue = calculate(dependency, props);
-  if (newValue !== dependencyValue) {
+  if (!shallowEqual(newValue, dependencyValue)) {
     setDependencyValue(newValue);
   }
   return dependencyValue;

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -79,7 +79,7 @@ export function shallowEqual(obj1: any, obj2: any): Boolean {
     // https://github.com/immutable-js/immutable-js/blob/59c291a2b37693198a0950637c5d55cd14dd6bc4/src/is.js#L52-L55
     if (obj1.hashCode() !== obj2.hashCode()) {
       return false;
-    } else {
+    } else if (typeof obj1.equals === 'function') {
       return obj1.equals(obj2);
     }
   }

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -63,6 +63,27 @@ export function shallowEqual(obj1: any, obj2: any): Boolean {
   if (obj1 === obj2) {
     return true;
   }
+
+  // Special handling for Immutables, as they must be handled specially.
+  // While this technically means this is deep equality for Immutables,
+  // it's better to have a more specific check than an entirely incorrect one.
+  if (
+    typeof obj1.hashCode === 'function' &&
+    typeof obj2.hashCode === 'function'
+  ) {
+    // `hashCode` is guaranteed to be the same if the objects are the same, but
+    // is NOT guaranteed to be different if the objects are different (hash
+    // collisions are possible). If the hash codes are different, then we can
+    // preemptively return false as a performance optimization. Otherwise,
+    // return the result of a call to `equals`.
+    // https://github.com/immutable-js/immutable-js/blob/59c291a2b37693198a0950637c5d55cd14dd6bc4/src/is.js#L52-L55
+    if (obj1.hashCode() !== obj2.hashCode()) {
+      return false;
+    } else {
+      return obj1.equals(obj2);
+    }
+  }
+
   if (typeof obj1 !== typeof obj2) {
     return false;
   }

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -1,5 +1,6 @@
 jest.unmock('../ObjectUtils');
 
+import { Map } from 'immutable';
 import {
   oForEach,
   oFilterMap,
@@ -85,6 +86,28 @@ describe('ObjectUtils', () => {
       expect(shallowEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(
         false
       );
+    });
+
+    it('shallowly compares immutable values', () => {
+      expect(shallowEqual(Map({ a: 1 }), Map({ a: 1 }))).toBe(true);
+      const mockImmutable1 = {
+        hashCode() {
+          return 1;
+        },
+        equals() {
+          return false;
+        },
+      };
+      const mockImmutable2 = {
+        hashCode() {
+          return 1;
+        },
+        equals() {
+          return false;
+        },
+      };
+      // force hash collision - should fall back to .equals
+      expect(shallowEqual(mockImmutable1, mockImmutable2)).toBe(false);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,6 +2371,11 @@ immutable-is@^3.7.4:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable-is/-/immutable-is-3.7.6.tgz#efad8bcf21443392402e10fa08b7aa91b65f6c30"
 
+immutable@4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 immutable@^3.7.4:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@ immutable-is@^3.7.4:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable-is/-/immutable-is-3.7.6.tgz#efad8bcf21443392402e10fa08b7aa91b65f6c30"
 
-immutable@4.0.0-rc.12:
-  version "4.0.0-rc.12"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
-  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+immutable@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+  integrity sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=
 
 immutable@^3.7.4:
   version "3.8.2"


### PR DESCRIPTION
fixes #74 

By using `shallowCompare` to test dependency changes, and having that function special-case immutable objects rather than just using strict equality, we can ensure that dependency values with nested immutable objects don't trigger infinite re-renders of the component they're in. 

This will be a minor performance regression for single-depth, primitive-only immutable objects by adding a function call to the stack, but will be a performance enhancement for most other cases by preventing unnecessary re-renders when non-primitive values are unchanged in value, even if they change in identity.

Chose to version this as 3.2.0 as there's a notable functionality change by moving to `shallowCompare` rather than `===`

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json`
- [x] `CHANGELOG.md` is up to date

@ditkin @colbyr 
