### PR TITLE
fix(ObjectUtils): only check for hashCode on truthy objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+* Fix shallowCompare function when one or both inputs is falsy.
+
 ## 3.2.0
 * Fix potential infinite loop with Immutable dependency values (#74)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "scripts": {

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -68,6 +68,8 @@ export function shallowEqual(obj1: any, obj2: any): Boolean {
   // While this technically means this is deep equality for Immutables,
   // it's better to have a more specific check than an entirely incorrect one.
   if (
+    obj1 &&
+    obj2 &&
     typeof obj1.hashCode === 'function' &&
     typeof obj2.hashCode === 'function'
   ) {

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -109,5 +109,9 @@ describe('ObjectUtils', () => {
       // force hash collision - should fall back to .equals
       expect(shallowEqual(mockImmutable1, mockImmutable2)).toBe(false);
     });
+
+    it('handles immutable values if one input is falsy', () => {
+      expect(() => shallowEqual(Map({ a: 1 }), null)).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
Previously, if the first value in a useStoreDependency call was immutable and the second was undefined or null, our checks would blow up. This tests to verify that the objects both exist before checking their members.

The test case fails without the provided patch.

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json`
- [x] `CHANGELOG.md` is up to date
