### PR TITLE
reapply perf fix from #84 to v3 branch

### DIFF
--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -59,31 +59,24 @@ export function oFilterMap<T, R>(
   );
 }
 
-export function shallowEqual(obj1: any, obj2: any): Boolean {
+function isImmutable(obj: any): boolean {
+  return (
+    obj &&
+    typeof obj.hashCode === 'function' &&
+    typeof obj.equals === 'function'
+  );
+}
+
+export function shallowEqual(obj1: any, obj2: any): boolean {
   if (obj1 === obj2) {
     return true;
   }
 
-  // Special handling for Immutables, as they must be handled specially.
+  // Special handling for FB Immutables, as they must be handled specially.
   // While this technically means this is deep equality for Immutables,
   // it's better to have a more specific check than an entirely incorrect one.
-  if (
-    obj1 &&
-    obj2 &&
-    typeof obj1.hashCode === 'function' &&
-    typeof obj2.hashCode === 'function'
-  ) {
-    // `hashCode` is guaranteed to be the same if the objects are the same, but
-    // is NOT guaranteed to be different if the objects are different (hash
-    // collisions are possible). If the hash codes are different, then we can
-    // preemptively return false as a performance optimization. Otherwise,
-    // return the result of a call to `equals`.
-    // https://github.com/immutable-js/immutable-js/blob/59c291a2b37693198a0950637c5d55cd14dd6bc4/src/is.js#L52-L55
-    if (obj1.hashCode() !== obj2.hashCode()) {
-      return false;
-    } else if (typeof obj1.equals === 'function') {
-      return obj1.equals(obj2);
-    }
+  if (isImmutable(obj1) && isImmutable(obj2)) {
+    return obj1.equals(obj2);
   }
 
   if (typeof obj1 !== typeof obj2) {
@@ -107,7 +100,11 @@ export function shallowEqual(obj1: any, obj2: any): Boolean {
       return false;
     }
     if (obj1.hasOwnProperty(property) && obj2.hasOwnProperty(property)) {
-      if (obj1[property] !== obj2[property]) {
+      if (isImmutable(obj1[property]) && isImmutable(obj2[property])) {
+        if (!obj1[property].equals(obj2[property])) {
+          return false;
+        }
+      } else if (obj1[property] !== obj2[property]) {
         return false;
       }
     }


### PR DESCRIPTION
Just a reapplication of the performance fix to `shallowEqual` from #84 onto v3. Will be published as `3.2.2`. See that PR for more information.