### PR TITLE
fix shallowCompare for arrays

### DIFF
--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -50,6 +50,21 @@ function isImmutable(obj: any): boolean {
   );
 }
 
+function _compareArrays(arr1: unknown[], arr2: unknown[]): boolean {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  if (!arr1.length) {
+    return true;
+  }
+  for (const idx in arr1) {
+    if (arr1[idx] !== arr2[idx]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function shallowEqual(obj1: any, obj2: any): boolean {
   if (obj1 === obj2) {
     return true;
@@ -87,6 +102,8 @@ export function shallowEqual(obj1: any, obj2: any): boolean {
         if (!obj1[property].equals(obj2[property])) {
           return false;
         }
+      } else if (Array.isArray(obj1[property])) {
+        return _compareArrays(obj1[property], obj2[property]);
       } else if (obj1[property] !== obj2[property]) {
         return false;
       }

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -87,6 +87,8 @@ describe('ObjectUtils', () => {
         false
       );
 
+      expect(shallowEqual({ a: [] }, { a: [1] })).toBe(false);
+      expect(shallowEqual({ a: [] }, { a: [] })).toBe(true);
       expect(shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, 3] })).toBe(true);
       expect(
         shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, { b: 'other' }] })

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -86,6 +86,11 @@ describe('ObjectUtils', () => {
       expect(shallowEqual({ a: 1, b: { c: 2 } }, { a: 1, b: { c: 2 } })).toBe(
         false
       );
+
+      expect(shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, 3] })).toBe(true);
+      expect(
+        shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, { b: 'other' }] })
+      ).toBe(false);
     });
 
     it('shallowly compares immutable values', () => {


### PR DESCRIPTION
If one of the top-level values in the returned object is an array, `shallowCompare` would always return `false` which would cause `connect` to spin in an infinite loop because deps were always different which means it would infinitely try to re-set the internal dependency value. By adding an explicit shallow comparison for arrays we can bypass this. Theoretically it could still be an issue if a dependency is rebuilding objects with new identities each `deref` and putting them into arrays, but that feels like behavior we should discourage since it'll break lots of other things like React's prop identity checking.

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [ ] version numbers are up to date in `package.json`
- [ ] `CHANGELOG.md` is up to date
