### PR TITLE
pass full dependency map to derefs

### DIFF
--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -65,8 +65,8 @@ describe('connect', () => {
       },
       third: {
         stores: [FirstStore, SecondStore],
-        deref: props => {
-          return FirstStore.get() + SecondStore.get(props.add || 0);
+        deref: (props, state) => {
+          return state.one + SecondStore.get(props.add || 0);
         },
       },
     };

--- a/src/dependencies/connect.tsx
+++ b/src/dependencies/connect.tsx
@@ -38,7 +38,7 @@ export default function connect<Deps extends DependencyMap>(
         enforceDispatcher(dispatcher);
 
         const [dependencyValue, setDependencyValue] = useState(() =>
-          calculateInitial(dependencies, props)
+          calculateInitial(dependencies, props, {}) || {}
         );
 
         const currProps = useCurrent(props);

--- a/src/dependencies/useStoreDependency.ts
+++ b/src/dependencies/useStoreDependency.ts
@@ -53,7 +53,7 @@ export function _useDispatchSubscription<
             Props,
             Partial<typeof dependencyMap>,
             DependencyMapType
-          >(dependencyMap, entry, currentProps.current);
+          >(dependencyMap, entry, currentProps.current, dependencyValue);
           if (!shallowEqual(newValue, dependencyValue)) {
             setDependencyValue((newValue as unknown) as DependenciesType);
           }


### PR DESCRIPTION
In the `connect` refactor I never ported the code to actually pass the full dependency map into the deref as the second `state` argument. This passes that value through and updates unit tests to catch this case