### PR TITLE
fix(shallowCompare): compare objects nested in arrays

### DIFF
--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -50,7 +50,8 @@ function isImmutable(obj: any): boolean {
   );
 }
 
-function _compareArrays(arr1: unknown[], arr2: unknown[]): boolean {
+function _compareArrays(arr1?: unknown[], arr2?: unknown[]): boolean {
+  if (!arr1 || !arr2) return false;
   if (arr1.length !== arr2.length) {
     return false;
   }
@@ -58,7 +59,11 @@ function _compareArrays(arr1: unknown[], arr2: unknown[]): boolean {
     return true;
   }
   for (const idx in arr1) {
-    if (arr1[idx] !== arr2[idx]) {
+    // this makes it _technically_ not a shallow equal for array values,
+    // but for stores that return arrays of objects, the object identities
+    // will likely not be equal so we should actually inspect the objects
+    // to see if they're equal
+    if (!shallowEqual(arr1[idx], arr2[idx])) {
       return false;
     }
   }
@@ -103,7 +108,7 @@ export function shallowEqual(obj1: any, obj2: any): boolean {
           return false;
         }
       } else if (
-        Array.isArray(obj1[property]) &&
+        Array.isArray(obj1[property]) ||
         Array.isArray(obj2[property])
       ) {
         return _compareArrays(obj1[property], obj2[property]);

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -88,8 +88,15 @@ describe('ObjectUtils', () => {
       );
 
       expect(shallowEqual({ a: [] }, { a: [1] })).toBe(false);
+      expect(shallowEqual({ a: [] }, { a: null })).toBe(false);
       expect(shallowEqual({ a: [] }, { a: [] })).toBe(true);
       expect(shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, 3] })).toBe(true);
+      expect(
+        shallowEqual(
+          { a: [1, 2, { b: 'other' }] },
+          { a: [1, 2, { b: 'other' }] }
+        )
+      ).toBe(true);
       expect(
         shallowEqual({ a: [1, 2, 3] }, { a: [1, 2, { b: 'other' }] })
       ).toBe(false);


### PR DESCRIPTION
Ran into another error case with arrays, so I made the decision to compare array values one level deeper. Otherwise, stores that return arrays of objects are very likely to get into an infinite loop. I left a comment explaining the new behavior and why we're not running a strictly shallow equality check