### PR TITLE
compare values rather than the entire state object

### DIFF
--- a/src/dependencies/__tests__/connect-test.js
+++ b/src/dependencies/__tests__/connect-test.js
@@ -161,7 +161,6 @@ describe('connect', () => {
           merged: {
             stores: [simpleArraysStore, complexArraysStore],
             deref(__, depMap) {
-              console.log(depMap);
               return (
                 depMap.simpleArraysStore &&
                 depMap.simpleArraysStore.concat(depMap.complexArraysStore)
@@ -177,6 +176,7 @@ describe('connect', () => {
       });
       // would not get here if array diffing wasn't working properly
       expect(root.find(BaseComponent).exists()).toBe(true);
+      root.unmount();
     });
   });
 
@@ -220,7 +220,9 @@ describe('connect', () => {
 
     it('only updates fields affected by the actionType', () => {
       const root = mount(<MockComponent />);
-      dispatcher.dispatch({ actionType: SHARED });
+      act(() => {
+        dispatcher.dispatch({ actionType: SHARED });
+      });
       act(() => {
         root.update();
       });

--- a/src/dependencies/connect.tsx
+++ b/src/dependencies/connect.tsx
@@ -37,8 +37,8 @@ export default function connect<Deps extends DependencyMap>(
       (props: GetProps<C>, ref) => {
         enforceDispatcher(dispatcher);
 
-        const [dependencyValue, setDependencyValue] = useState(() =>
-          calculateInitial(dependencies, props, {}) || {}
+        const [dependencyValue, setDependencyValue] = useState(
+          () => calculateInitial(dependencies, props, {}) || {}
         );
 
         const currProps = useCurrent(props);
@@ -54,7 +54,11 @@ export default function connect<Deps extends DependencyMap>(
         const newValue = oMap(dependencies, dep =>
           calculate(dep, props, dependencyValue)
         );
-        if (!shallowEqual(newValue, dependencyValue)) {
+        if (
+          Object.keys(newValue)
+            .map(k => shallowEqual(newValue[k], dependencyValue[k]))
+            .some(el => el === false)
+        ) {
           setDependencyValue(newValue as typeof dependencyValue);
         }
 

--- a/src/dependencies/useStoreDependency.ts
+++ b/src/dependencies/useStoreDependency.ts
@@ -54,7 +54,11 @@ export function _useDispatchSubscription<
             Partial<typeof dependencyMap>,
             DependencyMapType
           >(dependencyMap, entry, currentProps.current, dependencyValue);
-          if (!shallowEqual(newValue, dependencyValue)) {
+          if (
+            Object.keys(newValue)
+              .map(k => shallowEqual(newValue[k], dependencyValue[k]))
+              .some(el => !el)
+          ) {
             setDependencyValue((newValue as unknown) as DependenciesType);
           }
         }
@@ -96,7 +100,7 @@ function useStoreDependency<Props, DepType>(
   );
 
   const newValue = { dependency: calculate(dependency, props) };
-  if (!shallowEqual(newValue, dependencyValue)) {
+  if (!shallowEqual(newValue.dependency, dependencyValue.dependency)) {
     setDependencyValue(newValue);
   }
   return dependencyValue.dependency;

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -70,8 +70,15 @@ function _compareArrays(arr1?: unknown[], arr2?: unknown[]): boolean {
   return true;
 }
 
+// polyfill for Object.is
+function objectIs(x: any, y: any) {
+  return (
+    (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y) // eslint-disable-line no-self-compare
+  );
+}
+
 export function shallowEqual(obj1: any, obj2: any): boolean {
-  if (obj1 === obj2) {
+  if (objectIs(obj1, obj2)) {
     return true;
   }
 
@@ -112,7 +119,7 @@ export function shallowEqual(obj1: any, obj2: any): boolean {
         Array.isArray(obj2[property])
       ) {
         return _compareArrays(obj1[property], obj2[property]);
-      } else if (obj1[property] !== obj2[property]) {
+      } else if (!objectIs(obj1[property], obj2[property])) {
         return false;
       }
     }

--- a/src/utils/__tests__/ObjectUtils-test.js
+++ b/src/utils/__tests__/ObjectUtils-test.js
@@ -68,7 +68,7 @@ describe('ObjectUtils', () => {
   });
 
   describe('shallowEqual', () => {
-    it('shallowly compares values', () => {
+    it('compares values', () => {
       expect(shallowEqual(1, 1)).toBe(true);
       expect(shallowEqual(1, 0)).toBe(false);
 
@@ -102,7 +102,7 @@ describe('ObjectUtils', () => {
       ).toBe(false);
     });
 
-    it('shallowly compares immutable values', () => {
+    it('compares immutable values', () => {
       expect(shallowEqual(Map({ a: 1 }), Map({ a: 1 }))).toBe(true);
       const mockImmutable1 = {
         hashCode() {


### PR DESCRIPTION
Hopefully this is the last fix for object equality tests. @benbriggs pointed me to a problem in the Prospects app, as well as a couple other infinite loop cases that I noticed in the rest of the apps I attempted to upgrade.

It turns out that `React.useState` and `React.Component.prototype.setState` use two different equality algorithms! `useState` checks equality using an `Object.is` equivalent, but `setState` uses a deeper diffing algorithm. This means that `useState` will almost always fail to properly diff objects where `setState` was able to parse them just fine. To combat this, we'll instead run our shallowEqual comparison on each value in the state object rather than just the state object as a whole. This, as far as I can tell (React's codebase is incredibly hard to navigate), is equivalent to React's existing diffing algorithm for classes. If all else fails, we can convert `connect` back to a class component, but I'd really like to avoid that to avoid having to compile class syntax in the bundle.