### PR TITLE
use lazy state initialization to avoid eager deref calculation

### DIFF
--- a/src/dependencies/useStoreDependency.ts
+++ b/src/dependencies/useStoreDependency.ts
@@ -83,9 +83,9 @@ function useStoreDependency<Props, DepType>(
 ): DepType {
   enforceDispatcher(dispatcher);
 
-  const [dependencyValue, setDependencyValue] = useState({
+  const [dependencyValue, setDependencyValue] = useState(() => ({
     dependency: calculate(dependency, props),
-  });
+  }));
 
   const currProps = useCurrent(props);
 


### PR DESCRIPTION
h/t @gmcnaughton for pointing out that we can optimize this hook with a lazy state init to avoid double-calculating the deref on every render, which can be meaningful for expensive derefs 

**TODOs**

- [x] linter, checker, and test are passing
- [ ] any new public modules are exported from `src/GeneralStore.js`
- [ ] version numbers are up to date in `package.json`
- [ ] `CHANGELOG.md` is up to date
