### PR TITLE
avoids duplicate deref calculations in `useStoreDependency`

### DIFF
--- a/src/dependencies/useStoreDependency.ts
+++ b/src/dependencies/useStoreDependency.ts
@@ -83,9 +83,8 @@ function useStoreDependency<Props, DepType>(
 ): DepType {
   enforceDispatcher(dispatcher);
 
-  const [dependencyValue, setDependencyValue] = useState({
-    dependency: calculate(dependency, props),
-  });
+  const newValue = { dependency: calculate(dependency, props) };
+  const [dependencyValue, setDependencyValue] = useState(newValue);
 
   const currProps = useCurrent(props);
 
@@ -99,7 +98,6 @@ function useStoreDependency<Props, DepType>(
     setDependencyValue
   );
 
-  const newValue = { dependency: calculate(dependency, props) };
   if (!shallowEqual(newValue.dependency, dependencyValue.dependency)) {
     setDependencyValue(newValue);
     return newValue.dependency;


### PR DESCRIPTION
cc @aem - another possible approach to https://github.com/HubSpot/general-store/pull/95

Avoids duplicate deref calculations in `useStoreDependency`. Only calculate the value once; use it to initialize state (if needed) and as the new value.

When the value changes, two deref calculations will still run:

1. initial render/hook call
2. re-render/hook call triggered by setting the new value in state

**TODOs**

- [x] linter, checker, and test are passing
- [ ] any new public modules are exported from `src/GeneralStore.js`
- [ ] version numbers are up to date in `package.json`
- [ ] `CHANGELOG.md` is up to date
