### PR TITLE
Fix error connecting arrow function components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.1
+* Fix bug where `connect` threw errors when wrapping arrow function components.
+
 ## 4.1.0
 * Fix bug where useStoreDependency could return stale data, prevent expensive derefs from being called multiple times.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "4.1.1",
+  "version": "4.1.0",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "module": "dist/general-store.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "general-store",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Simple, flexible store implementation for Flux.",
   "main": "lib/GeneralStore.js",
   "module": "dist/general-store.esm.js",

--- a/src/dependencies/connect.tsx
+++ b/src/dependencies/connect.tsx
@@ -84,7 +84,8 @@ export default function connect<Deps extends DependencyMap>(
       }
 
       focus =
-        typeof BaseComponent.prototype.focus === 'function'
+        BaseComponent.prototype &&
+        typeof BaseComponent.prototype.focus === "function"
           ? (...args: any[]) => focuser(this, ...args)
           : undefined;
 


### PR DESCRIPTION
We are running in to an error `Cannot read properties of undefined (reading 'focus')` and traced it back to this code in `connect()` that assumes that all base components have a `prototype`. In spec-compliant ECMAScript an arrow function does not have a prototype so we have to guard against that.  

**TODOs**

- [x] linter, checker, and test are passing
- [x] any new public modules are exported from `src/GeneralStore.js`
- [x] version numbers are up to date in `package.json`
- [x] `CHANGELOG.md` is up to date
