### PR TITLE
ship ES2015 in ESM bundle

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,30 +42,25 @@ const bundle = env => {
   };
   return config;
 };
-const moduleBundleConfig = {
+const moduleBundle = format => ({
   input: './src/GeneralStore.ts',
   plugins: [
-    typescript(),
-    commonjs(),
-    resolve({
-      browser: true,
+    typescript({
+      target: format === 'esm' ? 'es2015' : 'es5'
     }),
   ],
   output: [
     {
-      file: `dist/general-store.cjs.js`,
-      format: 'cjs',
-    },
-    {
       file: `dist/general-store.esm.js`,
-      format: 'esm',
+      format
     },
   ],
   external: ['react', 'hoist-non-react-statics'],
-};
+});
 
 export default [
   bundle('development'),
   bundle('production'),
-  moduleBundleConfig,
+  moduleBundle('cjs'),
+  moduleBundle('esm'),
 ];


### PR DESCRIPTION
We should be able to shrink the module bundle by around 15% by targeting ES2015 instead of the default ESM. I also removed the CommonJS and Node resolve plugins from these bundles since they don't actually have any effect. 

- [ ] linter, checker, and test are passing
- [ ] any new public modules are exported from `src/GeneralStore.js`
- [ ] version numbers are up to date in `package.json`
- [ ] `CHANGELOG.md` is up to date
